### PR TITLE
Change the uiSchema structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Changed 
+
+* **UI Schema** Adapt the UI structure accordingly with the changes of `pages-editor.`
+
 ## [0.6.0] - 2018-04-30
 
 ## Added 

--- a/react/Carousel.js
+++ b/react/Carousel.js
@@ -33,6 +33,12 @@ const bannerProperties = {
     title: 'Type of route',
     default: 'internal',
     enum: ['internal', 'external'],
+    widget: {
+      'ui:widget': 'radio',
+      'ui:options': {
+        'inline': true,
+      },
+    },
   },
 }
 /**
@@ -45,17 +51,6 @@ class Carousel extends Component {
     this.state = {
       loading: true,
     }
-  }
-  static uiSchema = {
-    numberOfBanners: {
-      'ui:widget': 'range',
-    },
-    autoplaySpeed: {
-      'ui:widget': 'radio',
-      'ui:options': {
-        'inline': true,
-      },
-    },
   }
 
   static getSchema = props => {
@@ -140,6 +135,12 @@ class Carousel extends Component {
           title: 'Autoplay speed(sec):',
           default: 5,
           enum: [4, 5, 6],
+          widget: {
+            'ui:widget': 'radio',
+            'ui:options': {
+              'inline': true,
+            },
+          },
         } : {},
         numberOfBanners: {
           type: 'number',
@@ -147,6 +148,9 @@ class Carousel extends Component {
           default: 3,
           minimum: 1,
           maximum: 10,
+          widget: {
+            'ui:widget': 'range',
+          },
         },
         ...generatedSchema,
       },


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adjust the uiSchema to used the prop `widget` when we want to apply a custom ui to a prop. 

#### Screenshots or example usage
https://bruno--storecomponents.myvtexdev.com/carousel

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
