### PR TITLE
Add internationalization to the schema

### DIFF
--- a/react/Carousel.js
+++ b/react/Carousel.js
@@ -19,24 +19,28 @@ const DEFAULT_NUM_BANNERS = 3
 const bannerProperties = {
   image: {
     type: 'string',
-    title: 'Banner image',
+    title: 'editor.carousel.banner.image.title',
     default: '',
   },
   mobileImage: {
     type: 'string',
-    title: 'Banner mobile image',
+    title: 'editor.carousel.banner.mobileImage.title',
     default: '',
   },
   description: {
     type: 'string',
-    title: 'Banner description',
+    title: 'editor.carousel.banner.description.title',
     default: '',
   },
   typeOfRoute: {
     type: 'string',
-    title: 'Type of route',
+    title: 'editor.carousel.banner.typeOfRoute.title',
     default: 'internal',
     enum: ['internal', 'external'],
+    enumNames: [
+      'editor.carousel.banner.typeOfRoute.internal',
+      'editor.carousel.banner.typeOfRoute.external',
+    ],
     widget: {
       'ui:widget': 'radio',
       'ui:options': {
@@ -111,49 +115,41 @@ export default class Carousel extends Component {
     banner9: bannerProptype,
   }
 
-  static uiSchema = {
-    numberOfBanners: {
-      'ui:widget': 'range',
-    },
-    autoplaySpeed: {
-      'ui:widget': 'radio',
-      'ui:options': {
-        'inline': true,
-      },
-    },
-  }
-
   static getSchema = props => {
     const numberOfBanners = props.numberOfBanners || 3
     const autoplay = props.autoplay || false
 
     /** Defines an internal route or external link for the Banner */
-    const bannerLink = typeOfRoute =>
-      typeOfRoute === 'internal' ? {
-        page: {
-          type: 'string',
-          enum: GLOBAL_PAGES,
-          title: 'Banner target page',
-        },
-        params: {
-          type: 'string',
-          description: 'Comma separated params, e.g.: key=value,a=b,c=d',
-          title: 'Params',
-        },
-      }
-        : {
+    const bannerLink = typeOfRoute => {
+      if (typeOfRoute === 'internal') {
+        return {
           page: {
             type: 'string',
-            title: 'Banner link (should start with https or http)',
+            enum: GLOBAL_PAGES,
+            title: 'editor.carousel.bannerLink.page.title',
+          },
+          params: {
+            type: 'string',
+            description: 'editor.carousel.bannerLink.params.description',
+            title: 'editor.carousel.bannerLink.params.title',
           },
         }
+      }
 
-    const getRepeatedProperties = repetition =>
+      return {
+        page: {
+          type: 'string',
+          title: 'editor.carousel.bannerLink.title',
+        },
+      }
+    }
+
+    const getBannersSchema = repetition =>
       keyBy(
         map(range(0, repetition), index => {
           const typeOfRoute = props[`banner${index}`] && props[`banner${index}`].typeOfRoute
           return {
-            title: `Banner #${index + 1}`,
+            title: { id: 'editor.carousel.banner.title', values: { id: index + 1 } },
             key: `banner${index}`,
             type: 'object',
             properties: {
@@ -166,48 +162,47 @@ export default class Carousel extends Component {
       )
 
     const generatedSchema =
-      numberOfBanners && getRepeatedProperties(numberOfBanners)
+      numberOfBanners && getBannersSchema(numberOfBanners)
 
     if (props.numberOfBanners === undefined && generatedSchema.banner0) {
       generatedSchema.banner0.properties.image.default = defaultBannerProps(0).image
     }
 
     return {
-      title: 'Carousel',
-      description:
-        'A simple carousel component that shows a serie of banners with images and links',
+      title: 'editor.carousel.title',
+      description: 'editor.carousel.description',
       type: 'object',
       properties: {
         showDots: {
           type: 'boolean',
-          title: 'Show dots',
+          title: 'editor.carousel.showDots.title',
           default: true,
         },
         showArrows: {
           type: 'boolean',
-          title: 'Show arrows',
+          title: 'editor.carousel.showArrows.title',
           default: true,
         },
         height: {
           type: 'number',
-          title: 'Banner max height size (px)',
+          title: 'editor.carousel.height.title',
           default: 420,
           enum: [420, 440],
         },
         mobileHeight: {
           type: 'number',
-          title: 'Banner max height size on mobile (px)',
+          title: 'editor.carousel.mobileHeight.title',
           default: 339,
           enum: [339, 159],
         },
         autoplay: {
           type: 'boolean',
-          title: 'Autoplay',
+          title: 'editor.carousel.autoplay.title',
           default: true,
         },
         autoplaySpeed: autoplay ? {
           type: 'number',
-          title: 'Autoplay speed(sec):',
+          title: 'editor.carousel.autoplaySpeed.title',
           default: 5,
           enum: [4, 5, 6],
           widget: {
@@ -219,7 +214,7 @@ export default class Carousel extends Component {
         } : {},
         numberOfBanners: {
           type: 'number',
-          title: 'Number of banners',
+          title: 'editor.carousel.numberOfBanners.title',
           default: 3,
           minimum: 1,
           maximum: 10,

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -6,7 +6,7 @@
   "editor.carousel.height.title": "Banner max height size (px)",
   "editor.carousel.mobileHeight.title": "Banner max height size on mobile (px)",
   "editor.carousel.autoplay.title": "Autoplay",
-  "editor.carousel.autoplaySpeed.title": "Autoplay speed(sec):",
+  "editor.carousel.autoplaySpeed.title": "Autoplay speed (sec)",
   "editor.carousel.numberOfBanners.title": "Number of banners",
   "editor.carousel.bannerLink.title": "Banner link (should start with https or http)",
   "editor.carousel.bannerLink.page.title": "Banner target page",

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -1,0 +1,22 @@
+{
+  "editor.carousel.title": "Carousel",
+  "editor.carousel.description": "A simple carousel component that shows a serie of banners with images and links",
+  "editor.carousel.showDots.title": "Show dots",
+  "editor.carousel.showArrows.title": "Show arrows",
+  "editor.carousel.height.title": "Banner max height size (px)",
+  "editor.carousel.mobileHeight.title": "Banner max height size on mobile (px)",
+  "editor.carousel.autoplay.title": "Autoplay",
+  "editor.carousel.autoplaySpeed.title": "Autoplay speed(sec):",
+  "editor.carousel.numberOfBanners.title": "Number of banners",
+  "editor.carousel.bannerLink.title": "Banner link (should start with https or http)",
+  "editor.carousel.bannerLink.page.title": "Banner target page",
+  "editor.carousel.bannerLink.params.title": "Params",
+  "editor.carousel.bannerLink.params.description": "Comma separated params, e.g.: key=value,a=b,c=d",
+  "editor.carousel.banner.title": "Banner #{id}",
+  "editor.carousel.banner.description.title": "Banner description",
+  "editor.carousel.banner.typeOfRoute.title": "Type of route",
+  "editor.carousel.banner.typeOfRoute.internal": "Internal",
+  "editor.carousel.banner.typeOfRoute.external": "External",
+  "editor.carousel.banner.image.title": "Banner image",
+  "editor.carousel.banner.mobileImage.title": "Banner mobile image"
+}

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -1,6 +1,6 @@
 {
   "editor.carousel.title": "Carousel",
-  "editor.carousel.description": "A simple carousel component that shows a serie of banners with images and links",
+  "editor.carousel.description": "A simple carousel component that shows a serie of banners",
   "editor.carousel.showDots.title": "Show dots",
   "editor.carousel.showArrows.title": "Show arrows",
   "editor.carousel.height.title": "Banner max height size (px)",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -1,6 +1,6 @@
 {
   "editor.carousel.title": "Carrusel",
-  "editor.carousel.description": "Un simple componente de carrusel que muestra una serie de banners",
+  "editor.carousel.description": "Un componente básico de carrusel que muestra una serie de banners",
   "editor.carousel.showDots.title": "Mostrar puntos",
   "editor.carousel.showArrows.title": "Mostrar flechas de navegación",
   "editor.carousel.height.title": "Altura máxima del banner (px)",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -1,0 +1,22 @@
+{
+  "editor.carousel.title": "Carrusel",
+  "editor.carousel.description": "Un simple componente de carrusel que muestra una serie de banners",
+  "editor.carousel.showDots.title": "Mostrar puntos",
+  "editor.carousel.showArrows.title": "Mostrar flechas de navegación",
+  "editor.carousel.height.title": "Altura máxima del banner (px)",
+  "editor.carousel.mobileHeight.title": "Altura máxima del banner en el móvil (px)",
+  "editor.carousel.autoplay.title": "Reproducción automática",
+  "editor.carousel.autoplaySpeed.title": "Velocidad de reproducción automática (seg)",
+  "editor.carousel.numberOfBanners.title": "Número de banners",
+  "editor.carousel.bannerLink.title": "Enlace del banner (debe comenzar con http o https)",
+  "editor.carousel.bannerLink.page.title": "Página de destino del banner",
+  "editor.carousel.bannerLink.params.title": "Parámetros",
+  "editor.carousel.bannerLink.params.description": "Parámetros separados por coma, e.g.: clave=valor,a=b,c=d",
+  "editor.carousel.banner.title": "Banner #{id}",
+  "editor.carousel.banner.description.title": "Descripción del banner",
+  "editor.carousel.banner.typeOfRoute.title": "Tipo de ruta",
+  "editor.carousel.banner.typeOfRoute.internal": "Interna",
+  "editor.carousel.banner.typeOfRoute.external": "Externo",
+  "editor.carousel.banner.image.title": "Imagen del banner",
+  "editor.carousel.banner.mobileImage.title": "Imagen del banner en el móvil"
+}

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -1,0 +1,22 @@
+{
+  "editor.carousel.title": "Carrossel",
+  "editor.carousel.description": "Um simples componente de carrossel que mostra uma série de banners com imagens e links",
+  "editor.carousel.showDots.title": "Mostrar pontos",
+  "editor.carousel.showArrows.title": "Mostrar setas",
+  "editor.carousel.height.title": "Altura máxima do banner (px)",
+  "editor.carousel.mobileHeight.title": "Altura máxima do banner no mobile (px)",
+  "editor.carousel.autoplay.title": "Reprodução automática",
+  "editor.carousel.autoplaySpeed.title": "Velocidade da reprodução automática (seg)",
+  "editor.carousel.numberOfBanners.title": "Número de banners",
+  "editor.carousel.bannerLink.title": "Link do banner (deve começar com http ou https)",
+  "editor.carousel.bannerLink.page.title": "Página alvo do banner",
+  "editor.carousel.bannerLink.params.title": "Parâmetros",
+  "editor.carousel.bannerLink.params.description": "Parâmetros separados por vírgula, e.g.: chave=valor,a=b,c=d",
+  "editor.carousel.banner.title": "Banner #{id}",
+  "editor.carousel.banner.description.title": "Descrição do banner",
+  "editor.carousel.banner.typeOfRoute.title": "Tipo de rota",
+  "editor.carousel.banner.typeOfRoute.internal": "Interna",
+  "editor.carousel.banner.typeOfRoute.external": "Externa",
+  "editor.carousel.banner.image.title": "Imagem do banner",
+  "editor.carousel.banner.mobileImage.title": "Imagem do banner no mobile"
+}

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -1,8 +1,8 @@
 {
   "editor.carousel.title": "Carrossel",
-  "editor.carousel.description": "Um simples componente de carrossel que mostra uma série de banners com imagens e links",
+  "editor.carousel.description": "Um componente básico de carrossel que exibe uma série de banners",
   "editor.carousel.showDots.title": "Mostrar pontos",
-  "editor.carousel.showArrows.title": "Mostrar setas",
+  "editor.carousel.showArrows.title": "Mostrar setas de navegação",
   "editor.carousel.height.title": "Altura máxima do banner (px)",
   "editor.carousel.mobileHeight.title": "Altura máxima do banner no mobile (px)",
   "editor.carousel.autoplay.title": "Reprodução automática",


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add internationalization to the schema with english and portuguese languages.

#### What problem is this solving?
The component schema was only in english

#### How should this be manually tested?
[Access this workspace](https://lucas--storecomponents.myvtex.com/) and change the language to either english or portuguese and edit the carousel component.

#### Screenshots or example usage
N/A

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
