### PR TITLE
Update Slider dependency to use vtex.store-components 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Update `Slider` dependency to use `vtex.store-components` instead of `vtex.storecomponents`.  
+
 ## [1.0.3] - 2018-05-24
 ### Fixed
 - Fix the banner image size.

--- a/manifest.json
+++ b/manifest.json
@@ -16,15 +16,9 @@
   ],
   "settingsSchema": {},
   "scripts": {
-    "postreleasy": "vtex publish --public"
-  },
-  "billingOptions": {
-    "billingListeningRoute": "/_v/deactivateMePlease",
-    "termsURL": "http://route.to.the/terms",
-    "version": "0.1",
-    "free": true
+    "postreleasy": "vtex -r vtex --verbose"
   },
   "dependencies": {
-    "vtex.storecomponents": "1.x"
+    "vtex.store-components": "1.x"
   }
 }

--- a/react/Carousel.js
+++ b/react/Carousel.js
@@ -6,7 +6,7 @@ import map from 'lodash/map'
 import range from 'lodash/range'
 import property from 'lodash/property'
 
-import Slider from 'vtex.storecomponents/Slider'
+import { Slider } from 'vtex.store-components'
 import Banner from './Banner'
 import { NoSSR } from 'render'
 


### PR DESCRIPTION

#### What is the purpose of this pull request?
Update Slider dependency to use `vtex.store-components` instead of `vtex.storecomponents`
#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage
https://dev--storecomponents.myvtex.com/

#### Types of changes
- [] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
