### PR TITLE
Remove `mobileImage` and `mobileheight` from schema | Remove NoSSR tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Set `Banner`'s `image` property UI widget to `image-uploader`.
 - Set both routes properties into the `Banner`'s schema and add the flag `externalRoute`.
 
+### Removed
+- NoSSR.
+- `mobileImage` and `mobileheight` from schema.
+
+### Fixed
+- PropTypes warning.
+
 ## [1.1.0] - 2018-6-6
 ### Added
 - Add `isLayout` to schema properties.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - NoSSR.
 - `mobileImage` and `mobileheight` from schema.
 
-### Fixed
-- PropTypes warning.
-
 ## [1.1.0] - 2018-6-6
 ### Added
 - Add `isLayout` to schema properties.

--- a/react/Banner.js
+++ b/react/Banner.js
@@ -22,12 +22,10 @@ class Banner extends Component {
     const {
       height,
       image,
-      mobileImage,
       description,
       page,
       url,
       params,
-      mobileHeight,
       externalRoute,
     } = this.props
 
@@ -37,11 +35,6 @@ class Banner extends Component {
           className="vtex-carousel__img-regular"
           style={{ maxHeight: `${height}px` }}>
           <img className="w-100" src={image} alt={description} />
-        </div>
-        <div
-          className="vtex-carousel__img-mobile"
-          style={{ maxHeight: `${mobileHeight}px` }}>
-          <img className="w-100" src={mobileImage} alt={description} />
         </div>
       </div>
     )
@@ -67,10 +60,6 @@ Banner.propTypes = {
   image: PropTypes.string.isRequired,
   /** Max height size of the banner */
   height: PropTypes.number.isRequired,
-  /** The image of the banner on mobile */
-  mobileImage: PropTypes.string.isRequired,
-  /** Max height size of the banner on mobile  */
-  mobileHeight: PropTypes.number.isRequired,
   /** The description of the image */
   description: PropTypes.string.isRequired,
   /** The url where the image is pointing to, in case of external route */

--- a/react/Carousel.js
+++ b/react/Carousel.js
@@ -2,19 +2,11 @@ import './global.css'
 
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { NoSSR } from 'render'
 import { Slider } from 'vtex.store-components'
 
 import Banner from './Banner'
 
 const GLOBAL_PAGES = global.__RUNTIME__ && Object.keys(global.__RUNTIME__.pages)
-
-const defaultBannerProps = index => ({
-  image: `https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-0${index +
-    1}.png`,
-  page: 'store/home',
-  description: 'banner',
-})
 
 /**
  * Carousel component. Shows a serie of banners.
@@ -25,7 +17,6 @@ export default class Carousel extends Component {
     showArrows: true,
     showDots: true,
     height: 420,
-    mobileHeight: 339,
     autoplaySpeed: 5,
     banners: [],
   }
@@ -53,8 +44,6 @@ export default class Carousel extends Component {
     autoplaySpeed: PropTypes.number.isRequired,
     /** Max height size of the banners */
     height: PropTypes.number.isRequired,
-    /** Max height size of the banners on mobile */
-    mobileHeight: PropTypes.number.isRequired,
     /** Set visibility of dots */
     showDots: PropTypes.bool,
     /** Set visibility of arrows */
@@ -128,13 +117,6 @@ export default class Carousel extends Component {
           enum: [420, 440],
           isLayout: true,
         },
-        mobileHeight: {
-          type: 'number',
-          title: 'editor.carousel.mobileHeight.title',
-          default: 339,
-          enum: [339, 159],
-          isLayout: true,
-        },
         autoplay: {
           type: 'boolean',
           title: 'editor.carousel.autoplay.title',
@@ -158,11 +140,11 @@ export default class Carousel extends Component {
           : {},
         banners: {
           type: 'array',
-          title: 'Banners',
+          title: 'editor.carousel.banners.title',
           minItems: 1,
           items: {
             type: 'object',
-            title: 'Banner',
+            title: 'editor.carousel.banner.title',
             properties: {
               image: {
                 type: 'string',
@@ -208,47 +190,29 @@ export default class Carousel extends Component {
   }
 
   render() {
-    const { height, banners, mobileHeight } = this.props
+    const { height, banners } = this.props
     const settings = this.configureSettings()
 
-    const banner = defaultBannerProps(0)
-    const fallback = (
-      <div style={{ maxHeight: `${height}px` }} className="overflow-y-hidden">
-        <Banner
-          height={height}
-          image={banner.image}
-          description={banner.description}
-          mobileHeight={mobileHeight}
-          url={banner.url}
-          page={banner.page}
-          params={banner.params}
-          externalRoute={banner.externalRoute}
-        />
-      </div>
-    )
     return (
       <div className="vtex-carousel">
-        <NoSSR onSSR={fallback}>
-          <Slider sliderSettings={settings}>
-            {banners.map(
-              (banner, i) =>
-                banner &&
-                banner.image && (
-                  <div key={i} style={{ maxHeight: `${height}px` }}>
-                    <Banner
-                      height={height}
-                      image={banner.image}
-                      description={banner.description}
-                      mobileHeight={mobileHeight}
-                      page={banner.page}
-                      params={banner.params}
-                      typeOfRoute={banner.typeOfRoute}
-                    />
-                  </div>
-                )
-            )}
-          </Slider>
-        </NoSSR>
+        <Slider sliderSettings={settings}>
+          {banners.map(
+            (banner, i) =>
+              banner &&
+              banner.image && (
+                <div key={i} style={{ maxHeight: `${height}px` }}>
+                  <Banner
+                    height={height}
+                    image={banner.image}
+                    description={banner.description}
+                    page={banner.page}
+                    params={banner.params}
+                    typeOfRoute={banner.typeOfRoute}
+                  />
+                </div>
+              )
+          )}
+        </Slider>
       </div>
     )
   }

--- a/react/global.css
+++ b/react/global.css
@@ -7,10 +7,6 @@
   max-height: inherit;
 }
 
-.vtex-carousel .vtex-carousel__img-mobile {
-  display: none;
-}
-
 /* Arrows */
 
 .vtex-carousel .vtex-slider__arrow-left:before,
@@ -71,12 +67,4 @@
   .vtex-carousel .vtex-slider__arrow-right:before {
     display: none;
   }
-
-  .vtex-carousel .vtex-carousel__img-regular {
-    display: none;
-  }
-  .vtex-carousel .vtex-carousel__img-mobile {
-    display: block;
-  }
-
 }

--- a/react/locales/en-US.json
+++ b/react/locales/en-US.json
@@ -16,7 +16,8 @@
   "editor.carousel.bannerLink.params.description":
     "Comma separated params, e.g.: key=value,a=b,c=d",
   "editor.carousel.bannerLink.url.title": "URL (external)",
-  "editor.carousel.banner.title": "Banner #{id}",
+  "editor.carousel.banners.title": "Banners",
+  "editor.carousel.banner.title": "Banner",
   "editor.carousel.banner.description.title": "Banner description",
   "editor.carousel.banner.externalRoute.title": "External route",
   "editor.carousel.banner.image.title": "Banner image",

--- a/react/locales/es-AR.json
+++ b/react/locales/es-AR.json
@@ -19,7 +19,8 @@
   "editor.carousel.bannerLink.params.description":
     "Parámetros separados por coma, e.g.: clave=valor,a=b,c=d",
   "editor.carousel.bannerLink.url.title": "URL (externo)",
-  "editor.carousel.banner.title": "Banner #{id}",
+  "editor.carousel.banners.title": "Banners",
+  "editor.carousel.banner.title": "Banner",
   "editor.carousel.banner.description.title": "Descripción del banner",
   "editor.carousel.banner.externalRoute.title": "Ruta externa",
   "editor.carousel.banner.image.title": "Imagen del banner",

--- a/react/locales/pt-BR.json
+++ b/react/locales/pt-BR.json
@@ -18,7 +18,8 @@
   "editor.carousel.bannerLink.params.description":
     "Parâmetros separados por vírgula, e.g.: chave=valor,a=b,c=d",
   "editor.carousel.bannerLink.url.title": "URL (externa)",
-  "editor.carousel.banner.title": "Banner #{id}",
+  "editor.carousel.banners.title": "Banners",
+  "editor.carousel.banner.title": "Banner",
   "editor.carousel.banner.description.title": "Descrição do banner",
   "editor.carousel.banner.externalRoute.title": "Rota externa",
   "editor.carousel.banner.image.title": "Imagem do banner",


### PR DESCRIPTION
#### What is the purpose of this pull request?
- Removed NoSSR.
- Removed `mobileImage` and `mobileheight` from schema and PropTypes.

#### What problem is this solving?
![screenshot from 2018-07-23 14-52-24](https://user-images.githubusercontent.com/4960686/43094420-33059954-8e89-11e8-96b9-69e0d72d10ae.png)

#### How should this be manually tested?
[workspace link](https://claudivan--storecomponents.myvtex.com/)
#### Screenshots or example usage

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
