### PR TITLE
Add `Carousel` support to work together with `MainCategories`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Verification of empty array of Banners.
+
 ## [1.2.2] - 2018-08-01
 ### Changed
 - Set `Banner`'s `image` property UI widget to `image-uploader`.

--- a/react/Carousel.js
+++ b/react/Carousel.js
@@ -125,18 +125,18 @@ export default class Carousel extends Component {
         },
         autoplaySpeed: autoplay
           ? {
-            type: 'number',
-            title: 'editor.carousel.autoplaySpeed.title',
-            default: 5,
-            enum: [4, 5, 6],
-            widget: {
-              'ui:widget': 'radio',
-              'ui:options': {
-                inline: true,
+              type: 'number',
+              title: 'editor.carousel.autoplaySpeed.title',
+              default: 5,
+              enum: [4, 5, 6],
+              widget: {
+                'ui:widget': 'radio',
+                'ui:options': {
+                  inline: true,
+                },
               },
-            },
-            isLayout: true,
-          }
+              isLayout: true,
+            }
           : {},
         banners: {
           type: 'array',
@@ -192,6 +192,8 @@ export default class Carousel extends Component {
   render() {
     const { height, banners } = this.props
     const settings = this.configureSettings()
+
+    if (!banners.length) return null
 
     return (
       <div className="vtex-carousel">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add `Carousel` support to work together with `MainCategories`.

#### What problem is this solving?
The MainCategories component should be located partially above the Carousel component in the department page template. When a Carousel does not contain any Banner the MainCategories component should be on the top of the page without overlap any component be it partially or not.

#### How should this be manually tested?

#### Screenshots or example usage
With banners: https://gugabribeiro--storecomponents.myvtex.com/veiculos/d

![captura de tela de 2018-08-03 10-59-04](https://user-images.githubusercontent.com/9275109/43646799-4118cac6-970c-11e8-969e-3b1b9beb3aee.png)

Without any banner: https://gugabribeiro--storecomponents.myvtex.com/eletronicos/d

![captura de tela de 2018-08-03 11-00-00](https://user-images.githubusercontent.com/9275109/43646848-621a4fc4-970c-11e8-9835-b504b66aae05.png)

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
