### PR TITLE
Fix error when clicking in an image that doesn't have a url to go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.1.1] - 2018-12-19
 ### Fixed
 - Error when clicking in an image that doesn't have a url to go.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Error when clicking in an image that doesn't have a url to go.
 
 ## [2.1.0] - 2018-12-04
 ### Added

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "carousel",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "title": "Carousel",
   "description": "Carousel Component",
   "defaultLocale": "pt-BR",

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -38,7 +38,7 @@ class Banner extends Component<Props> {
     /** The image of the banner */
     image: PropTypes.string.isRequired,
     /** The mobile image of the banner */
-  mobileImage: PropTypes.string,
+    mobileImage: PropTypes.string,
     /** The page where the image is pointing to */
     page: PropTypes.string,
     /** Params of the url */
@@ -72,25 +72,25 @@ class Banner extends Component<Props> {
       <div className="vtex-carousel__img-container">
         <div
           className="vtex-carousel__img-regular"
-          style={{ maxHeight: `${height}px` }}
+          style={{ maxHeight: height }}
         >
-          <img className="w-100" src={isMobile && mobileImage ? mobileImage: image} alt={description} />
+          <img className="w-100" src={isMobile && mobileImage ? mobileImage : image} alt={description} />
         </div>
       </div>
     )
 
-    return !externalRoute ? (
-      <div>
+    if (!externalRoute) {
+      return page ? (
         <Link page={page} params={this.getParams(params)}>
           {content}
         </Link>
-      </div>
-    ) : (
-      <div>
-        <a href={url} target="_blank">
-          {content}
-        </a>
-      </div>
+      ) : content
+    }
+
+    return (
+      <a href={url} target="_blank">
+        {content}
+      </a>
     )
   }
 

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -124,18 +124,18 @@ export default class Carousel extends Component<Props> {
         },
         autoplaySpeed: autoplay
           ? {
-              default: 5,
-              enum: [4, 5, 6],
-              isLayout: true,
-              title: 'editor.carousel.autoplaySpeed.title',
-              type: 'number',
-              widget: {
-                'ui:options': {
-                  inline: true,
-                },
-                'ui:widget': 'radio',
+            default: 5,
+            enum: [4, 5, 6],
+            isLayout: true,
+            title: 'editor.carousel.autoplaySpeed.title',
+            type: 'number',
+            widget: {
+              'ui:options': {
+                inline: true,
               },
-            }
+              'ui:widget': 'radio',
+            },
+          }
           : {},
         banners: {
           minItems: 1,
@@ -208,15 +208,13 @@ export default class Carousel extends Component<Props> {
 
     return (
       <div className="vtex-carousel force-full-width">
-        <Slider sliderSettings={settings} leftArrowClasses={'ml3 ml5-m ml8-l ml9-xl'}  rightArrowClasses={'mr3 mr5-m mr8-l mr9-xl'}>
-          {banners.map(
-            (banner, i) =>
-              banner &&
-              (banner.mobileImage || banner.image) && (
-                <div key={i} style={{ maxHeight: `${height}px` }}>
-                  <Banner height={height} {...banner} />
-                </div>
-              )
+        <Slider sliderSettings={settings} leftArrowClasses="ml3 ml5-m ml8-l ml9-xl" rightArrowClasses="mr3 mr5-m mr8-l mr9-xl">
+          {banners.filter(banner => banner && (banner.mobileImage || banner.image)).map(
+            (banner, i) => (
+              <div key={i} style={{ maxHeight: height }}>
+                <Banner height={height} {...banner} />
+              </div>
+            )
           )}
         </Slider>
       </div>

--- a/react/__mocks__/render.js
+++ b/react/__mocks__/render.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, cloneElement } from 'react'
 
 /**
  * Link Mocked Component.
@@ -16,4 +16,10 @@ export class NoSSR extends Component {
   render() {
     return this.props.children
   }
+}
+
+export function withRuntimeContext(MyComponent) {
+    return props => {
+      return <MyComponent runtime={{ hints: {} }} {...props} />
+    }
 }

--- a/react/__tests__/Carousel.test.js
+++ b/react/__tests__/Carousel.test.js
@@ -15,6 +15,9 @@ describe('Carousel component', () => {
     autoplay: true,
     autoplaySpeed: 4,
     numberOfBanners: 3,
+    runtime: {
+      hints: {}
+    },
     banners: [
       {
         image:

--- a/react/__tests__/__snapshots__/Carousel.test.js.snap
+++ b/react/__tests__/__snapshots__/Carousel.test.js.snap
@@ -8,77 +8,71 @@ exports[`Carousel component should match snapshot 1`] = `
     <div
       style="max-height: 440px;"
     >
-      <div>
-        <a
-          href="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
-          target="_blank"
+      <a
+        href="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
+        target="_blank"
+      >
+        <div
+          class="vtex-carousel__img-container"
         >
           <div
-            class="vtex-carousel__img-container"
+            class="vtex-carousel__img-regular"
+            style="max-height: 440px;"
           >
-            <div
-              class="vtex-carousel__img-regular"
-              style="max-height: 440px;"
-            >
-              <img
-                alt="banner"
-                class="w-100"
-                src="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
-              />
-            </div>
+            <img
+              alt="banner"
+              class="w-100"
+              src="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
+            />
           </div>
-        </a>
-      </div>
+        </div>
+      </a>
     </div>
     <div
       style="max-height: 440px;"
     >
-      <div>
-        <a
-          href="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
-          target="_blank"
+      <a
+        href="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
+        target="_blank"
+      >
+        <div
+          class="vtex-carousel__img-container"
         >
           <div
-            class="vtex-carousel__img-container"
+            class="vtex-carousel__img-regular"
+            style="max-height: 440px;"
           >
-            <div
-              class="vtex-carousel__img-regular"
-              style="max-height: 440px;"
-            >
-              <img
-                alt="david"
-                class="w-100"
-                src="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-02.png"
-              />
-            </div>
+            <img
+              alt="david"
+              class="w-100"
+              src="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-02.png"
+            />
           </div>
-        </a>
-      </div>
+        </div>
+      </a>
     </div>
     <div
       style="max-height: 440px;"
     >
-      <div>
-        <a
-          href="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
-          target="_blank"
+      <a
+        href="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-01.png"
+        target="_blank"
+      >
+        <div
+          class="vtex-carousel__img-container"
         >
           <div
-            class="vtex-carousel__img-container"
+            class="vtex-carousel__img-regular"
+            style="max-height: 440px;"
           >
-            <div
-              class="vtex-carousel__img-regular"
-              style="max-height: 440px;"
-            >
-              <img
-                alt="banner"
-                class="w-100"
-                src="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-03.png"
-              />
-            </div>
+            <img
+              alt="banner"
+              class="w-100"
+              src="https://raw.githubusercontent.com/vtex-apps/carousel/master/images/banners-03.png"
+            />
           </div>
-        </a>
-      </div>
+        </div>
+      </a>
     </div>
   </div>
 </div>


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?
As title says.

#### How should this be manually tested?
[Workspace](https://linkerrorcarousel--storecomponents.myvtex.com/)

#### Screenshots or example usage
Before:
![captura de tela de 2018-12-12 16-58-47](https://user-images.githubusercontent.com/8517023/49895435-2c99e000-fe2f-11e8-9ac0-32927683f75d.png)
After: The error doesn't happen

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
