### PR TITLE
[onHold] Add text with action button option on Banner

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,6 @@
   },
   "dependencies": {
     "vtex.store-components": "3.x",
-    "vtex.styleguide": "8.x"
+    "vtex.styleguide": "9.x"
   }
 }

--- a/manifest.json
+++ b/manifest.json
@@ -15,6 +15,7 @@
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
-    "vtex.store-components": "3.x"
+    "vtex.store-components": "3.x",
+    "vtex.styleguide": "8.x"
   }
 }

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -21,5 +21,13 @@
   "editor.carousel.banner.description.title": "Banner description",
   "editor.carousel.banner.externalRoute.title": "External route",
   "editor.carousel.banner.image.title": "Banner image",
-  "editor.carousel.banner.mobileImage.title": "Banner mobile image"
+  "editor.carousel.banner.mobileImage.title": "Banner mobile image",
+  "editor.carousel.banner.textMode.button.title": "Button Title (Image/Text Mode)",
+  "editor.carousel.banner.textMode.button.externalRouteButton": "Button with external route (Image/text mode)",
+  "editor.carousel.banner.textMode.button.pageButton": "Button target page (Image/text mode)",
+  "editor.carousel.banner.textMode.button.paramsButton": "Button params (Image/Text Mode)",
+  "editor.carousel.banner.textMode.button.urlButton": "External button URL (Image/text mode)",
+  "editor.carousel.banner.textMode.textTitle": "Text title (Image/text mode)",
+  "editor.carousel.banner.textMode.textDescription": "Text description (Image/text mode)",
+  "editor.carousel.banner.textMode.title": "Image text mode"
 }

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -24,5 +24,13 @@
   "editor.carousel.banner.description.title": "Descripción del banner",
   "editor.carousel.banner.externalRoute.title": "Ruta externa",
   "editor.carousel.banner.image.title": "Imagen del banner",
-  "editor.carousel.banner.mobileImage.title": "Imagen del banner en el móvil"
+  "editor.carousel.banner.mobileImage.title": "Imagen del banner en el móvil",
+  "editor.carousel.banner.textMode.button.title": "Titulo del botón (Modo imagen / texto)",
+  "editor.carousel.banner.textMode.button.externalRouteButton": "Botón con ruta externa (Modo imagen / texto)",
+  "editor.carousel.banner.textMode.button.pageButton": "Página de destino del botón (Modo de imagen / texto)",
+  "editor.carousel.banner.textMode.button.paramsButton": "Parámetros del botón (Modo imagen / texto)",
+  "editor.carousel.banner.textMode.button.urlButton": "URL externa del botón (Modo imagen / texto)",
+  "editor.carousel.banner.textMode.textTitle": "Titulo del texto (Modo imagen / texto)",
+  "editor.carousel.banner.textMode.textDescription": "Descripción del texto (Modo imagen / texto)",
+  "editor.carousel.banner.textMode.title": "Modo de texto con imagen"
 }

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -23,5 +23,13 @@
   "editor.carousel.banner.description.title": "Descrição do banner",
   "editor.carousel.banner.externalRoute.title": "Rota externa",
   "editor.carousel.banner.image.title": "Imagem do banner",
-  "editor.carousel.banner.mobileImage.title": "Imagem do banner no mobile"
+  "editor.carousel.banner.mobileImage.title": "Imagem do banner no mobile",
+  "editor.carousel.banner.textMode.button.title": "Titulo do botão (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.button.externalRouteButton": "Botão com rota externa (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.button.pageButton": "Página alvo do botão (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.button.paramsButton": "Parâmetros do botão (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.button.urlButton": "URL externa do botão (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.textTitle": "Titulo do texto (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.textDescription": "Descrição do texto (Modo imagem/texto)",
+  "editor.carousel.banner.textMode.title": "Modo de texto com imagem"
 }

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Link, withRuntimeContext } from 'vtex.render-runtime'
+import { Button } from 'vtex.styleguide'
 
 interface DefaultProps {
   /** Max height size of the banner */
@@ -53,6 +54,32 @@ class Banner extends Component<Props> {
     height: 420,
   }
 
+  public displayButton() {
+    const {    
+      externalRouteButton,  
+      urlButton,
+      pageButton,
+      paramsButton,
+      buttonTitle,
+    } = this.props
+    return (
+      <div>
+        {!externalRouteButton ? (
+          <Link page={pageButton} params={this.getParams(paramsButton)}>
+            <Button primary>
+              {buttonTitle}
+            </Button>
+          </Link>) : (
+          <a href={urlButton} target="_blank">
+            <Button primary>
+              {buttonTitle}
+            </Button>
+          </a>)
+        }
+      </div>
+    )
+  }
+
   public render() {
     const {
       height,
@@ -63,19 +90,44 @@ class Banner extends Component<Props> {
       url,
       params,
       externalRoute,
+      textImageMode,
+      textTitle,
+      textDescription,
       runtime
     } = this.props
 
     const isMobile = runtime.hints.mobile
 
+    let containerInlineClasses = {}
+    if (textImageMode) {
+      containerInlineClasses = {
+        minHeight: height,
+        objectFit: "cover",
+      }
+    } else {
+      containerInlineClasses = {
+        maxHeight: height,
+      }
+    }
+
     const content = (
-      <div className="vtex-carousel__img-container">
-        <div
-          className="vtex-carousel__img-regular"
-          style={{ maxHeight: height }}
-        >
-          <img className="w-100" src={isMobile && mobileImage ? mobileImage : image} alt={description} />
+      <div  className="vtex-carousel__img-container flex">
+        <div className="vtex-carousel__img-regular">
+          <img style={containerInlineClasses} className="w-100" src={isMobile && mobileImage ? mobileImage : image} alt={description} />
         </div>
+        {textImageMode && (
+          <div className="w-50-ns absolute pt8-l pb4-l pt5-m pb3-m pv6-s pl6">
+            <div>
+              <h1>{textTitle}</h1>
+            </div>
+            <div className="pb6 pt5-ns lh-title black">
+              {textDescription}
+            </div>
+            <div>
+              {this.displayButton()}
+            </div>
+          </div>
+        )}
       </div>
     )
 

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -24,7 +24,23 @@ export interface Props extends DefaultProps {
   /** Indicates if the route is external or not */
   externalRoute: boolean
   /** Runtime injected deps */
-  runtime: any
+  runtime: any,
+  /** Indicates if the route of the button is external or not */
+  externalRouteButton: boolean,
+  /** The url where the button is pointing to, in case of external route */
+  urlButton: string,
+  /** The page where the button is pointing to */
+  pageButton: string,
+  /** Params of the button url */
+  paramsButton: string,
+  /** Indicates if the banner is a text banner or not */
+  textImageMode: boolean,
+  /** The title of the button on the image text mode */
+  buttonTitle: string,
+  /** The title of the text on the image text mode */
+  textTitle: string,
+  /** The description of the button on the image text mode */
+  textDescription: string,
 }
 
 /**
@@ -44,10 +60,26 @@ class Banner extends Component<Props> {
     mobileImage: PropTypes.string,
     /** The page where the image is pointing to */
     page: PropTypes.string,
-    /** Params of the url */
+    /** Params of the image url */
     params: PropTypes.string,
     /** The url where the image is pointing to, in case of external route */
     url: PropTypes.string,
+    /** Indicates if the route of the button is external or not */
+    externalRouteButton: PropTypes.bool,
+    /** The url where the button is pointing to, in case of external route */
+    urlButton: PropTypes.string,
+    /** The page where the button is pointing to */
+    pageButton: PropTypes.string,
+    /** Params of the button url */
+    paramsButton: PropTypes.string,
+    /** Indicates if the banner is a text banner or not */
+    textImageMode: PropTypes.bool,
+    /** The title of the button on the image text mode */
+    buttonTitle: PropTypes.string,
+    /** The title of the text on the image text mode */
+    textTitle: PropTypes.string,
+    /** The description of the button on the image text mode */
+    textDescription: PropTypes.string,
   }
 
   public static defaultProps: DefaultProps = {
@@ -74,8 +106,8 @@ class Banner extends Component<Props> {
             <Button primary>
               {buttonTitle}
             </Button>
-          </a>)
-        }
+          </a>
+        )}
       </div>
     )
   }

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -75,6 +75,12 @@ export default class Carousel extends Component<Props> {
         typeOfRoute: PropTypes.string,
         /** The url where the image is pointing to, in case of external route */
         url: PropTypes.string,
+        /** The text title of the image */
+        textTitle: PropTypes.string.isRequired,
+        /** The text description of the image */
+        textDescription: PropTypes.string.isRequired,
+        /** The button title of the image */
+        buttonTitle: PropTypes.string.isRequired,
       })
     ),
     /** Max height size of the banners */
@@ -103,11 +109,58 @@ export default class Carousel extends Component<Props> {
       },
     }
 
+    const buttonRouteSchema = {
+      externalRouteButton: {
+        title: 'editor.carousel.banner.textMode.button.externalRouteButton',
+        type: 'boolean',
+        default: false,
+        isLayout: false,
+      },
+      pageButton: {
+        enum: GLOBAL_PAGES,
+        isLayout: false,
+        title: 'editor.carousel.banner.textMode.button.pageButton',
+        type: 'string',
+      },
+      paramsButton: {
+        description: 'editor.carousel.bannerLink.params.description',
+        isLayout: false,
+        title: 'editor.carousel.banner.textMode.button.paramsButton',
+        type: 'string',
+      },
+      urlButton: {
+        isLayout: false,
+        title: 'editor.carousel.banner.textMode.button.urlButton',
+        type: 'string',
+      },
+    }
+
     const externalRouteSchema = {
       url: {
         isLayout: false,
         title: 'editor.carousel.bannerLink.url.title',
         type: 'string',
+      },
+    }
+
+    const textModeSchema = {
+      textTitle: {
+        title: 'editor.carousel.banner.textMode.textTitle',
+        type: 'string',
+        isLayout: false,
+      },
+      textDescription: {
+        title: 'editor.carousel.banner.textMode.textDescription',
+        type: 'string',
+        isLayout: false,
+        widget: {
+          'ui:widget': 'textarea',
+        },
+      },
+      buttonTitle: {
+        title: 'editor.carousel.banner.textMode.button.title',
+        type: 'string',
+        isLayout: false,
       },
     }
 
@@ -145,17 +198,6 @@ export default class Carousel extends Component<Props> {
             title: 'editor.carousel.banner.title',
             type: 'object',
             properties: { // tslint:disable-line
-              description: {
-                default: '',
-                title: 'editor.carousel.banner.description.title',
-                type: 'string',
-              },
-              externalRoute: {
-                title: 'editor.carousel.banner.externalRoute.title',
-                type: 'boolean',
-              },
-              ...externalRouteSchema,
-              ...internalRouteSchema,
               image: {
                 default: '',
                 title: 'editor.carousel.banner.image.title',
@@ -172,6 +214,25 @@ export default class Carousel extends Component<Props> {
                   'ui:widget': 'image-uploader',
                 },
               },
+              description: {
+                default: '',
+                title: 'editor.carousel.banner.description.title',
+                type: 'string',
+              },
+              externalRoute: {
+                title: 'editor.carousel.banner.externalRoute.title',
+                type: 'boolean',
+                isLayout: false,
+              },
+              ...externalRouteSchema,
+              ...internalRouteSchema,
+              textImageMode: {
+                title: 'editor.carousel.banner.textMode.title',
+                type: 'boolean',
+                default: false,
+              },
+              ...textModeSchema,
+              ...buttonRouteSchema,
             },
           },
         },

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -75,12 +75,22 @@ export default class Carousel extends Component<Props> {
         typeOfRoute: PropTypes.string,
         /** The url where the image is pointing to, in case of external route */
         url: PropTypes.string,
-        /** The text title of the image */
-        textTitle: PropTypes.string.isRequired,
-        /** The text description of the image */
-        textDescription: PropTypes.string.isRequired,
-        /** The button title of the image */
-        buttonTitle: PropTypes.string.isRequired,
+        /** Indicates if the route of the button is external or not */
+        externalRouteButton: PropTypes.bool,
+        /** The url where the button is pointing to, in case of external route */
+        urlButton: PropTypes.string,
+        /** The page where the button is pointing to */
+        pageButton: PropTypes.string,
+        /** Params of the button url */
+        paramsButton: PropTypes.string,
+        /** Indicates if the banner is a text banner or not */
+        textImageMode: PropTypes.string,
+        /** The title of the button on the image text mode */
+        buttonTitle: PropTypes.string,
+        /** The title of the text on the image text mode */
+        textTitle: PropTypes.string,
+        /** The description of the text on the image text mode */
+        textDescription: PropTypes.bool,
       })
     ),
     /** Max height size of the banners */


### PR DESCRIPTION
#### What is the purpose of this pull request?
Add funcionality of a banner with text and a action button.

#### What problem is this solving?
There was no option to add text on the banner.

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
