### PR TITLE
Fix images not fitting correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- images of banner not fitting correctly when needs to be larger than really is.
 
 ## [2.7.0] - 2019-02-28
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.7.1] - 2019-03-01
 ### Fixed
 - images of banner not fitting correctly when needs to be larger than really is.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "carousel",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "title": "Carousel",
   "description": "Carousel Component",
   "defaultLocale": "pt-BR",

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -59,13 +59,13 @@ const Banner = (props: Props) => {
   const { mobile: isMobile } = useRuntime().hints
 
   const content = (
-    <div className={styles.containerImg}>
+    <div className={classnames(styles.containerImg, 'w-100')}>
       <div
         className={classnames(styles.imgRegular, 'flex items-center justify-center')}
         style={{ maxHeight: height }}
       >
         <img
-          className={classnames('w-100 h-100', styles.img)}
+          className={classnames(styles.img, 'w-100 h-100')}
           src={isMobile && mobileImage ? mobileImage : image}
           alt={description}
         />


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?
When you put an image that doesn't have a specific  resolution, it doesn't look good.

#### How should this be manually tested?
Access this [workspace](https://fixresizecarousel--storecomponents.myvtex.com/) and go to the thrid slide, after that you can remove the class `w-100` of the element `containerImg`

#### Screenshots or example usage
Before:
![captura de tela de 2019-03-01 09-33-42](https://user-images.githubusercontent.com/8517023/53638416-ec175a80-3c04-11e9-9f67-0bfe4367dc10.png)

After:
![captura de tela de 2019-03-01 09-32-42](https://user-images.githubusercontent.com/8517023/53638369-c9854180-3c04-11e9-860e-c3c3b7a929b8.png)


#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
