### PR TITLE
Fix banner external route option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Fix tests.
+- External route not working on storefront.
 
 ## [2.7.1] - 2019-03-01
 

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -1,7 +1,6 @@
 {
   "editor.carousel.title": "Carousel",
-  "editor.carousel.description":
-    "A simple carousel component that shows a serie of banners",
+  "editor.carousel.description": "A simple carousel component that shows a serie of banners",
   "editor.carousel.showDots.title": "Show dots",
   "editor.carousel.showArrows.title": "Show arrows",
   "editor.carousel.height.title": "Banner max height size (px)",
@@ -9,12 +8,10 @@
   "editor.carousel.autoplay.title": "Autoplay",
   "editor.carousel.autoplaySpeed.title": "Autoplay speed (sec)",
   "editor.carousel.numberOfBanners.title": "Number of banners",
-  "editor.carousel.bannerLink.title":
-    "Banner link (should start with https or http)",
+  "editor.carousel.bannerLink.title": "Banner link (should start with https or http)",
   "editor.carousel.bannerLink.page.title": "Banner target page (internal)",
   "editor.carousel.bannerLink.params.title": "Params (internal)",
-  "editor.carousel.bannerLink.params.description":
-    "Comma separated params, e.g.: key=value,a=b,c=d",
+  "editor.carousel.bannerLink.params.description": "Comma separated params, e.g.: key=value,department=Accessories",
   "editor.carousel.bannerLink.url.title": "URL (external)",
   "editor.carousel.banners.title": "Banners",
   "editor.carousel.banner.title": "Banner",

--- a/messages/es-AR.json
+++ b/messages/es-AR.json
@@ -1,23 +1,17 @@
 {
   "editor.carousel.title": "Carrusel",
-  "editor.carousel.description":
-    "Un componente básico de carrusel que muestra una serie de banners",
+  "editor.carousel.description": "Un componente básico de carrusel que muestra una serie de banners",
   "editor.carousel.showDots.title": "Mostrar puntos",
   "editor.carousel.showArrows.title": "Mostrar flechas de navegación",
   "editor.carousel.height.title": "Altura máxima del banner (px)",
-  "editor.carousel.mobileHeight.title":
-    "Altura máxima del banner en el móvil (px)",
+  "editor.carousel.mobileHeight.title": "Altura máxima del banner en el móvil (px)",
   "editor.carousel.autoplay.title": "Reproducción automática",
-  "editor.carousel.autoplaySpeed.title":
-    "Velocidad de reproducción automática (seg)",
+  "editor.carousel.autoplaySpeed.title": "Velocidad de reproducción automática (seg)",
   "editor.carousel.numberOfBanners.title": "Número de banners",
-  "editor.carousel.bannerLink.title":
-    "Enlace del banner (debe comenzar con http o https)",
-  "editor.carousel.bannerLink.page.title":
-    "Página de destino del banner (interna)",
+  "editor.carousel.bannerLink.title": "Enlace del banner (debe comenzar con http o https)",
+  "editor.carousel.bannerLink.page.title": "Página de destino del banner (interna)",
   "editor.carousel.bannerLink.params.title": "Parámetros (interna)",
-  "editor.carousel.bannerLink.params.description":
-    "Parámetros separados por coma, e.g.: clave=valor,a=b,c=d",
+  "editor.carousel.bannerLink.params.description": "Parámetros separados por coma, e.g.: clave=valor,department=Accessories",
   "editor.carousel.bannerLink.url.title": "URL (externo)",
   "editor.carousel.banners.title": "Banners",
   "editor.carousel.banner.title": "Banner",

--- a/messages/pt-BR.json
+++ b/messages/pt-BR.json
@@ -1,22 +1,17 @@
 {
   "editor.carousel.title": "Carrossel",
-  "editor.carousel.description":
-    "Um componente básico de carrossel que exibe uma série de banners",
+  "editor.carousel.description": "Um componente básico de carrossel que exibe uma série de banners",
   "editor.carousel.showDots.title": "Mostrar pontos",
   "editor.carousel.showArrows.title": "Mostrar setas de navegação",
   "editor.carousel.height.title": "Altura máxima do banner (px)",
-  "editor.carousel.mobileHeight.title":
-    "Altura máxima do banner no mobile (px)",
+  "editor.carousel.mobileHeight.title": "Altura máxima do banner no mobile (px)",
   "editor.carousel.autoplay.title": "Reprodução automática",
-  "editor.carousel.autoplaySpeed.title":
-    "Velocidade da reprodução automática (seg)",
+  "editor.carousel.autoplaySpeed.title": "Velocidade da reprodução automática (seg)",
   "editor.carousel.numberOfBanners.title": "Número de banners",
-  "editor.carousel.bannerLink.title":
-    "Link do banner (deve começar com http ou https)",
+  "editor.carousel.bannerLink.title": "Link do banner (deve começar com http ou https)",
   "editor.carousel.bannerLink.page.title": "Página alvo do banner (interna)",
   "editor.carousel.bannerLink.params.title": "Parâmetros (interna)",
-  "editor.carousel.bannerLink.params.description":
-    "Parâmetros separados por vírgula, e.g.: chave=valor,a=b,c=d",
+  "editor.carousel.bannerLink.params.description": "Parâmetros separados por vírgula, e.g.: chave=valor,department=Accessories",
   "editor.carousel.bannerLink.url.title": "URL (externa)",
   "editor.carousel.banners.title": "Banners",
   "editor.carousel.banner.title": "Banner",

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -76,8 +76,6 @@ const Banner = (props: Props) => {
     </div>
   )
 
-  console.log('route', externalRoute)
-
   if (!externalRoute) {
     return page ? (
       <Link

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -76,6 +76,8 @@ const Banner = (props: Props) => {
     </div>
   )
 
+  console.log('route', externalRoute)
+
   if (!externalRoute) {
     return page ? (
       <Link

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -272,8 +272,6 @@ export default class Carousel extends Component<Props, State> {
       banner => banner && (banner.mobileImage || banner.image)
     )
 
-    console.log('tst', banners)
-
     return (
       <SliderContainer
         autoplay={autoplay}

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -54,12 +54,6 @@ export default class Carousel extends Component<Props, State> {
   public static uiSchema = {
     banners: {
       items: {
-        externalRoute: {
-          'ui:options': {
-            inline: true,
-          },
-          'ui:widget': 'radio',
-        },
         image: {
           'ui:widget': 'image-uploader',
         },
@@ -85,7 +79,7 @@ export default class Carousel extends Component<Props, State> {
         /** The page where the image is pointing to */
         page: PropTypes.string,
         /** Params of the url */
-        params: PropTypes.object,
+        params: PropTypes.string,
         /** Indicates if the route is external or internal */
         typeOfRoute: PropTypes.string,
         /** The url where the image is pointing to, in case of external route */
@@ -130,7 +124,8 @@ export default class Carousel extends Component<Props, State> {
       description: 'editor.carousel.description',
       title: 'editor.carousel.title',
       type: 'object',
-      properties: { // tslint:disable-line
+      properties: {
+        // tslint:disable-line
         autoplay: {
           default: true,
           isLayout: true,
@@ -139,33 +134,37 @@ export default class Carousel extends Component<Props, State> {
         },
         autoplaySpeed: autoplay
           ? {
-            default: 5,
-            enum: [4, 5, 6],
-            isLayout: true,
-            title: 'editor.carousel.autoplaySpeed.title',
-            type: 'number',
-            widget: {
-              'ui:options': {
-                inline: true,
+              default: 5,
+              enum: [4, 5, 6],
+              isLayout: true,
+              title: 'editor.carousel.autoplaySpeed.title',
+              type: 'number',
+              widget: {
+                'ui:options': {
+                  inline: true,
+                },
+                'ui:widget': 'radio',
               },
-              'ui:widget': 'radio',
-            },
-          }
+            }
           : {},
         banners: {
           minItems: 1,
           title: 'editor.carousel.banners.title',
           type: 'array',
-          items: { // tslint:disable-line
+          items: {
+            // tslint:disable-line
             title: 'editor.carousel.banner.title',
             type: 'object',
-            properties: { // tslint:disable-line
+            properties: {
+              // tslint:disable-line
               description: {
                 default: '',
                 title: 'editor.carousel.banner.description.title',
                 type: 'string',
               },
               externalRoute: {
+                default: false,
+                isLayout: false,
                 title: 'editor.carousel.banner.externalRoute.title',
                 type: 'boolean',
               },
@@ -214,7 +213,7 @@ export default class Carousel extends Component<Props, State> {
   }
 
   public state = {
-    currentSlide: 0
+    currentSlide: 0,
   }
 
   public handleChangeSlide = (i: number): void => {
@@ -224,19 +223,23 @@ export default class Carousel extends Component<Props, State> {
   public handleNextSlide = (): void => {
     this.setState(({ currentSlide }) => {
       const bannersLength: number = this.props.banners.filter(
-        banner => banner && (banner.mobileImage || banner.image)).length
+        banner => banner && (banner.mobileImage || banner.image)
+      ).length
       const nextSlide: number = (currentSlide + 1) % bannersLength
 
       return {
-        currentSlide: nextSlide
+        currentSlide: nextSlide,
       }
     })
   }
 
-  public ArrowRender: React.StatelessComponent<ArrowProps> = ({ orientation, onClick }: ArrowProps) => {
+  public ArrowRender: React.StatelessComponent<ArrowProps> = ({
+    orientation,
+    onClick,
+  }: ArrowProps) => {
     const containerClasses = classnames(styles.arrow, 'pointer z-1', {
       [styles.leftArrow]: orientation === 'left',
-      [styles.rightArrow]: orientation === 'right'
+      [styles.rightArrow]: orientation === 'right',
     })
     return (
       <div className={containerClasses} onClick={onClick}>
@@ -245,28 +248,20 @@ export default class Carousel extends Component<Props, State> {
     )
   }
 
-  public ArrowContainerRender: React.StatelessComponent<ArrowContainerProps> = ({ children }: ArrowContainerProps) => {
+  public ArrowContainerRender: React.StatelessComponent<
+    ArrowContainerProps
+  > = ({ children }: ArrowContainerProps) => {
     const containerClasses = classnames(
       styles.arrowContainer,
       'w-100 h-100 absolute flex-ns justify-between left-0',
       'top-0 items-center dn-s'
     )
 
-    return (
-      <Container className={containerClasses}>
-        {children}
-      </Container>
-    )
+    return <Container className={containerClasses}>{children}</Container>
   }
 
   public render() {
-    const {
-      height,
-      showArrows,
-      autoplay,
-      autoplaySpeed,
-      showDots
-    } = this.props
+    const { height, showArrows, autoplay, autoplaySpeed, showDots } = this.props
     const { currentSlide } = this.state
 
     if (!this.props.banners.length) {
@@ -274,7 +269,10 @@ export default class Carousel extends Component<Props, State> {
     }
 
     const banners: BannerProps[] = this.props.banners.filter(
-      banner => banner && (banner.mobileImage || banner.image))
+      banner => banner && (banner.mobileImage || banner.image)
+    )
+
+    console.log('tst', banners)
 
     return (
       <SliderContainer
@@ -287,7 +285,7 @@ export default class Carousel extends Component<Props, State> {
         <Slider
           classes={{
             root: styles.sliderRoot,
-            sliderFrame: styles.sliderFrame
+            sliderFrame: styles.sliderFrame,
           }}
           arrowRender={showArrows && this.ArrowRender}
           currentSlide={currentSlide}
@@ -295,13 +293,16 @@ export default class Carousel extends Component<Props, State> {
           arrowsContainerComponent={showArrows && this.ArrowContainerRender}
           duration={500}
         >
-          {banners.map(
-            (banner, i) => (
-              <Slide className={styles.slide} key={i} style={{ maxHeight: height }} sliderTransitionDuration={500}>
-                <Banner height={height} {...banner} />
-              </Slide>
-            )
-          )}
+          {banners.map((banner, i) => (
+            <Slide
+              className={styles.slide}
+              key={i}
+              style={{ maxHeight: height }}
+              sliderTransitionDuration={500}
+            >
+              <Banner height={height} {...banner} />
+            </Slide>
+          ))}
         </Slider>
         {showDots && (
           <Dots
@@ -312,7 +313,7 @@ export default class Carousel extends Component<Props, State> {
               root: classnames(styles.containerDots, 'bottom-0 pb4'),
               notActiveDot: classnames(styles.notActiveDot, 'bg-muted-3'),
               dot: classnames(styles.dot, 'mh2 mv0 pointer br-100'),
-              activeDot: classnames(styles.activeDot, 'bg-emphasis')
+              activeDot: classnames(styles.activeDot, 'bg-emphasis'),
             }}
           />
         )}


### PR DESCRIPTION
#### What is the purpose of this pull request?
FIx banner external route option

#### What problem is this solving?
The banner external route was not been showing on the storefront as an option.

#### How should this be manually tested?
[Access the storefront](https://theoo--storecomponents.myvtex.com/admin/cms/storefront) and go to carousel section.

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
