### PR TITLE
Arrow container not fitting well on large screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.7.3] - 2019-03-08
 ### Fixed
 
 - Missing namespaces in docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+
+- Missing namespaces in docs.
+- The container of arrows not fitting properly on large screens.
+
 ### Removed
 
 - Unused classes of `styles.css`.
@@ -16,8 +21,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix tests.
 - External route not working on storefront.
-- Missing namespaces in docs.
-- The container of arrows not fitting properly on large screens.
 
 ## [2.7.1] - 2019-03-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Removed
+
+- Unused classes of `styles.css`.
 
 ## [2.7.2] - 2019-03-07
 
@@ -13,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Fix tests.
 - External route not working on storefront.
+- Missing namespaces in docs.
+- The container of arrows not fitting properly on large screens.
 
 ## [2.7.1] - 2019-03-01
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,11 @@ Below, we describe the namespaces that are defined in the `Carousel`.
 | `sliderRoot` | The main container of the `Slider` | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
 | `sliderFrame` | The element that contains the Slides | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
 | `slide` | The container of the `Banner` component | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
+| `arrow` | The container of the arrow svg (this namespace is applied to both arrows) | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
+| `leftArrow` | The container of the left arrow svg | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
+| `rightArrow` | The container of the right arrow svg | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
+| `arrowsContainerWrapper` | The wrapper of the container of the arrows | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
+| `arrowsContainer` | The container of the arrows | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
 | `containerDots` | The main container of the dots | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
 | `notActiveDot` | The element of the dots that are not actives | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|
 | `dot` | The element of the dot | [Carousel](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Carousel.tsx)|

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "carousel",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "title": "Carousel",
   "description": "Carousel Component",
   "defaultLocale": "pt-BR",

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -251,13 +251,19 @@ export default class Carousel extends Component<Props, State> {
   public ArrowContainerRender: React.StatelessComponent<
     ArrowContainerProps
   > = ({ children }: ArrowContainerProps) => {
+    const wrapperClasses = classnames(styles.arrowsContainerWrapper, 'w-100 h-100 absolute left-0 top-0 flex justify-center')
     const containerClasses = classnames(
-      styles.arrowContainer,
-      'w-100 h-100 absolute flex-ns justify-between left-0',
-      'top-0 items-center dn-s'
+      styles.arrowsContainer,
+      'w-100 h-100 mw9 flex-ns justify-between items-center dn-s'
     )
 
-    return <Container className={containerClasses}>{children}</Container>
+    return (
+      <div className={wrapperClasses}>
+        <Container className={containerClasses}>
+          {children}
+        </Container>
+      </div>
+    )
   }
 
   public render() {

--- a/react/styles.css
+++ b/react/styles.css
@@ -7,30 +7,6 @@
   max-height: inherit;
 }
 
-.containerDots {}
-
-.notActiveDot {}
-
-.activeDot {}
-
-.slide {}
-
-.sliderRoot {}
-
-.sliderFrame {}
-
-.arrow {}
-
-.leftArrow {}
-
-.rightArrow {}
-
-.imgRegular {}
-
-.img {}
-
-.bannerLink {}
-
 .dot {
   height: 10px;
   width: 10px;


### PR DESCRIPTION
#### What is the purpose of this pull request? What problem is this solving?
As title says.

#### How should this be manually tested?
Access the [workspace](https://fixcarouselarrows--storecomponents.myvtex.com/) and put in a large size of screen

#### Screenshots or example usage
Before:
![screenshot from 2019-03-07 12-16-36](https://user-images.githubusercontent.com/8517023/53966913-e9b87300-40d2-11e9-8043-e07e5d19828f.png)

Now:
![screenshot from 2019-03-07 12-15-48](https://user-images.githubusercontent.com/8517023/53966844-cb527780-40d2-11e9-8cde-08845eaa900d.png)


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Requires change to documentation, which has been updated accordingly.
