### PR TITLE
Reorder schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- Change order of `Carousel`'s schema properties to improve UX in Site Editor.
+
 ## [2.10.0] - 2019-07-29
 ### Added
 - Autoplay configuration on the Storefront.

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -118,6 +118,7 @@ export default class Carousel extends Component<Props, State> {
       },
     }
 
+    // tslint:disable:object-literal-sort-keys
     return {
       description: 'admin/editor.carousel.description',
       dependencies: {
@@ -133,32 +134,16 @@ export default class Carousel extends Component<Props, State> {
                   isLayout: false,
                   title: 'admin/editor.carousel.autoplaySpeed.title',
                   type: 'string',
-                }
-              }
-            }
-          ]
-        }
+                },
+              },
+            },
+          ],
+        },
       },
       properties: {
-        // tslint:disable-line
         banners: {
           items: {
-            // tslint:disable-line
             properties: {
-              // tslint:disable-line
-              description: {
-                default: '',
-                title: 'admin/editor.carousel.banner.description.title',
-                type: 'string',
-              },
-              externalRoute: {
-                default: false,
-                isLayout: false,
-                title: 'admin/editor.carousel.banner.externalRoute.title',
-                type: 'boolean',
-              },
-              ...externalRouteSchema,
-              ...internalRouteSchema,
               image: {
                 default: '',
                 title: 'admin/editor.carousel.banner.image.title',
@@ -175,6 +160,19 @@ export default class Carousel extends Component<Props, State> {
                   'ui:widget': 'image-uploader',
                 },
               },
+              description: {
+                default: '',
+                title: 'admin/editor.carousel.banner.description.title',
+                type: 'string',
+              },
+              externalRoute: {
+                default: false,
+                isLayout: false,
+                title: 'admin/editor.carousel.banner.externalRoute.title',
+                type: 'boolean',
+              },
+              ...externalRouteSchema,
+              ...internalRouteSchema,
             },
             title: 'admin/editor.carousel.banner.title',
             type: 'object',
@@ -212,6 +210,7 @@ export default class Carousel extends Component<Props, State> {
       title: 'admin/editor.carousel.title',
       type: 'object',
     }
+    // tslint:enable
   }
 
   public state = {

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -51,19 +51,6 @@ export default class Carousel extends Component<Props, State> {
     showDots: true,
   }
 
-  public static uiSchema = {
-    banners: {
-      items: {
-        image: {
-          'ui:widget': 'image-uploader',
-        },
-        mobileImage: {
-          'ui:widget': 'image-uploader',
-        },
-      },
-    },
-  }
-
   public static propTypes = {
     /** Should change images automatically */
     autoplay: PropTypes.bool.isRequired,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Change `Carousel` schema to have images on top.
I know relying on object key order is wrong but it works ¯\_(ツ)_/¯ and I think it's better than (`if image uploader`...).

#### What problem is this solving?
Bad UX for carousel.

#### Screenshots or example usage
In site editor
- Before
![Screen Shot 2019-08-05 at 16 20 03](https://user-images.githubusercontent.com/10400340/62489822-27aee580-b79e-11e9-890a-5846007b1425.png)

- After
![Screen Shot 2019-08-05 at 16 19 39](https://user-images.githubusercontent.com/10400340/62489827-2da4c680-b79e-11e9-8ae2-a17ab66ab00c.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
