### PR TITLE
Bugfix - CSS namespace classes not being applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,45 +7,66 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- `activeDots` and `notActive` classes not being applied to the rendered `<Dots />` component.
+
 ## [2.10.1] - 2019-08-05
 
 ### Changed
+
 - Change order of `Carousel`'s schema properties to improve UX in Site Editor.
 
 ## [2.10.0] - 2019-07-29
+
 ### Added
+
 - Autoplay configuration on the Storefront.
 
 ## [2.9.2] - 2019-06-27
+
 ### Fixed
+
 - Build assets with new builder hub.
 
 ## [2.9.1] - 2019-05-26
+
 ### Fixed
+
 - Add default empty description to Carousel image. (For decorative images, it's recommended to insert an empty string to the alt attribute rather than to leave it empty).
 
 ## [2.9.0] - 2019-04-24
+
 ### Changed
+
 - Scope messages
 
 ## [2.8.0] - 2019-03-25
+
 ### Changed
+
 - Use `loop` prop of `Slider` app.
 
 ## [2.7.6] - 2019-03-14
+
 ### Changed
+
 - Change language files to most generic.
 
 ## [2.7.5] - 2019-03-13
+
 ### Fixed
+
 - Arrows container not aligned.
 
 ### Changed
+
 - Make arrows thinner.
 
 ## [2.7.4] - 2019-03-13
 
 ## [2.7.3] - 2019-03-08
+
 ### Fixed
 
 - Missing namespaces in docs.

--- a/react/styles.css
+++ b/react/styles.css
@@ -16,5 +16,12 @@
   box-sizing: content-box;
 }
 
-.arrowLeft {}
-.arrowRight {}
+.arrowLeft {
+}
+.arrowRight {
+}
+
+.activeDot {
+}
+.notActiveDot {
+}


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add missing CSS classes namespace definition on `react/styles.css`.

This should solve https://github.com/vtex-apps/store-discussion/issues/19

#### What problem is this solving?

Fix a bug where the CSS classes `.activeDot` and `.notActiveDot` supposed to be applied to the `<Dots />` component (from `vtex.slider`) were not being applied.

#### How should this be manually tested?

https://victorhmp--storecomponents.myvtex.com/

#### Screenshots or example usage

On `store-theme/styles/css/vtex.carousel`:

```
.activeDot {
  background-color: #FFF;
}
.notActiveDot {
  background-color: #000;
}
```

<img width="1680" alt="Screen Shot 2019-08-05 at 5 11 25 PM" src="https://user-images.githubusercontent.com/27777263/62492130-1a94f500-b7a4-11e9-8b73-5f3da739706c.png">



#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
