### PR TITLE
Add items per page and text property on banner image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - PerPage configuration on the Storefront.
 
+- Text configuration on the Storefront.
+
 ## [2.11.4] - 2019-10-25
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.12.0] - 2019-11-06
+
+### Added
+
+- PerPage configuration on the Storefront.
+
 ## [2.11.4] - 2019-10-25
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Banner:
 | `image`             | `String`  | Link for the image of the banner                                                | N/A           |
 | `mobileImage`       | `String`  | Link for the mobile image of the banner                                         | N/A           |
 | `description`       | `String`  | The image's description                                                         | N/A           |
+| `text`              | `String`  | The image's text                                                             | N/A           |
 | `url`               | `String`  | The URL where the image is pointing to, in case of external route               | N/A           |
 | `page`              | `String`  | The page where the image is pointing to                                         | N/A           |
 | `params`            | `String`  | Parameters of the URL                                                           | N/A           |
@@ -147,6 +148,7 @@ Below, we describe the namespaces that are defined in the `Carousel`.
 | `imgRegular`             | The wrapper of the `img` element used to center the image inside the container | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
 | `img`                    | The `img` element                                                              | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
 | `bannerLink`             | The `a` element that wraps the whole `Banner` component                        | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
+| `imgText`             | The `imgText` element                         | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
 
 ## Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,19 @@ See our [LTS policy](https://github.com/vtex-apps/awesome-io#lts-policy) for mor
 
 ## Table of Contents
 
-- [Usage](#usage)
-  - [Blocks API](#blocks-api)
-    - [Configuration](#configuration)
-  - [Styles API](#styles-api)
-    - [CSS namespaces](#css-namespaces)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [Tests](#tests)
+- [VTEX Carousel](#vtex-carousel)
+  - [Description](#description)
+  - [Release schedule](#release-schedule)
+  - [Table of Contents](#table-of-contents)
+  - [Usage](#usage)
+    - [Blocks API](#blocks-api)
+      - [Configuration](#configuration)
+    - [Styles API](#styles-api)
+      - [CSS namespaces](#css-namespaces)
+  - [Troubleshooting](#troubleshooting)
+  - [Contributing](#contributing)
+  - [Tests](#tests)
+    - [Travis CI](#travis-ci)
 
 ## Usage
 
@@ -48,6 +53,7 @@ Now, you can change the behavior of the carousel block that is in the store head
 "carousel#home": {
     "props": {
       "autoplay": true,
+      "perPage": 1,
       "autoplaySpeed": 4,
       "banners": [],
       "height": 440,
@@ -76,6 +82,7 @@ Through the Storefront, you can change the carousel's behavior and interface. Ho
 | Prop name       | Type            | Description                                        | Default value |
 | --------------- | --------------- | -------------------------------------------------- | ------------- |
 | `autoplay`      | `Boolean`       | Enable automatic banner transition                 | true          |
+| `perPage`       | `Number`        | Set the number of per page in the carousel         | 1             |
 | `autoplaySpeed` | `Number`        | Set the automatic banner transition interval       | 5             |
 | `showDots`      | `Boolean`       | Shows the carousel dots                            | true          |
 | `showArrows`    | `Boolean`       | Shows the carousel arrows                          | true          |

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,14 +17,19 @@ See our [LTS policy](https://github.com/vtex-apps/awesome-io#lts-policy) for mor
 
 ## Table of Contents
 
-- [Usage](#usage)
-  - [Blocks API](#blocks-api)
-    - [Configuration](#configuration)
-  - [Styles API](#styles-api)
-    - [CSS namespaces](#css-namespaces)
-- [Troubleshooting](#troubleshooting)
-- [Contributing](#contributing)
-- [Tests](#tests)
+- [VTEX Carousel](#vtex-carousel)
+  - [Description](#description)
+  - [Release schedule](#release-schedule)
+  - [Table of Contents](#table-of-contents)
+  - [Usage](#usage)
+    - [Blocks API](#blocks-api)
+      - [Configuration](#configuration)
+    - [Styles API](#styles-api)
+      - [CSS namespaces](#css-namespaces)
+  - [Troubleshooting](#troubleshooting)
+  - [Contributing](#contributing)
+  - [Tests](#tests)
+    - [Travis CI](#travis-ci)
 
 ## Usage
 
@@ -48,6 +53,7 @@ Now, you can change the behavior of the carousel block that is in the store head
 "carousel#home": {
     "props": {
       "autoplay": true,
+      "perPage": 1,
       "autoplaySpeed": 4,
       "banners": [],
       "height": 440,
@@ -76,6 +82,7 @@ Through the Storefront, you can change the carousel's behavior and interface. Ho
 | Prop name       | Type            | Description                                        | Default value |
 | --------------- | --------------- | -------------------------------------------------- | ------------- |
 | `autoplay`      | `Boolean`       | Enable automatic banner transition                 | true          |
+| `perPage`       | `Number`        | Set the number of per page in the carousel         | 1             |
 | `autoplaySpeed` | `Number`        | Set the automatic banner transition interval       | 5             |
 | `showDots`      | `Boolean`       | Shows the carousel dots                            | true          |
 | `showArrows`    | `Boolean`       | Shows the carousel arrows                          | true          |
@@ -89,6 +96,7 @@ Banner:
 | `image`             | `String`  | Link for the image of the banner                                                | N/A           |
 | `mobileImage`       | `String`  | Link for the mobile image of the banner                                         | N/A           |
 | `description`       | `String`  | The image's description                                                         | N/A           |
+| `text`              | `String`  | The image's text                                                             | N/A           |
 | `url`               | `String`  | The URL where the image is pointing to, in case of external route               | N/A           |
 | `page`              | `String`  | The page where the image is pointing to                                         | N/A           |
 | `params`            | `String`  | Parameters of the URL                                                           | N/A           |
@@ -140,6 +148,7 @@ Below, we describe the namespaces that are defined in the `Carousel`.
 | `imgRegular`             | The wrapper of the `img` element used to center the image inside the container | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
 | `img`                    | The `img` element                                                              | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
 | `bannerLink`             | The `a` element that wraps the whole `Banner` component                        | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
+| `imgText`             | The `imgText` element                         | [Banner](https://github.com/vtex-apps/carousel/blob/feature/new-slider/react/Banner.tsx)     |
 
 ## Troubleshooting
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -3,6 +3,7 @@
   "admin/editor.carousel.description": "admin/editor.carousel.description",
   "admin/editor.carousel.showDots.title": "admin/editor.carousel.showDots.title",
   "admin/editor.carousel.showArrows.title": "admin/editor.carousel.showArrows.title",
+  "admin/editor.carousel.perPage.title": "admin/editor.carousel.perPage.title",
   "admin/editor.carousel.height.title": "admin/editor.carousel.height.title",
   "admin/editor.carousel.mobileHeight.title": "admin/editor.carousel.mobileHeight.title",
   "admin/editor.carousel.autoplay.title": "admin/editor.carousel.autoplay.title",

--- a/messages/context.json
+++ b/messages/context.json
@@ -19,6 +19,7 @@
   "admin/editor.carousel.banners.title": "admin/editor.carousel.banners.title",
   "admin/editor.carousel.banner.title": "admin/editor.carousel.banner.title",
   "admin/editor.carousel.banner.description.title": "admin/editor.carousel.banner.description.title",
+  "admin/editor.carousel.banner.text.title": "admin/editor.carousel.banner.text.title",
   "admin/editor.carousel.banner.externalRoute.title": "admin/editor.carousel.banner.externalRoute.title",
   "admin/editor.carousel.banner.image.title": "admin/editor.carousel.banner.image.title",
   "admin/editor.carousel.banner.mobileImage.title": "admin/editor.carousel.banner.mobileImage.title"

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,7 @@
   "admin/editor.carousel.description": "A simple carousel component that shows a serie of banners",
   "admin/editor.carousel.showDots.title": "Show dots",
   "admin/editor.carousel.showArrows.title": "Show arrows",
+  "admin/editor.carousel.perPage.title": "Items per page",
   "admin/editor.carousel.height.title": "Banner max height size (px)",
   "admin/editor.carousel.mobileHeight.title": "Banner max height size on mobile (px)",
   "admin/editor.carousel.autoplay.title": "Autoplay",

--- a/messages/en.json
+++ b/messages/en.json
@@ -19,6 +19,7 @@
   "admin/editor.carousel.banners.title": "Banners",
   "admin/editor.carousel.banner.title": "Banner",
   "admin/editor.carousel.banner.description.title": "Banner description",
+  "admin/editor.carousel.banner.text.title": "Banner text",
   "admin/editor.carousel.banner.externalRoute.title": "External route",
   "admin/editor.carousel.banner.image.title": "Banner image",
   "admin/editor.carousel.banner.mobileImage.title": "Banner mobile image"

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,6 +3,7 @@
   "admin/editor.carousel.description": "Un componente básico de carrusel que muestra una serie de banners",
   "admin/editor.carousel.showDots.title": "Mostrar puntos",
   "admin/editor.carousel.showArrows.title": "Mostrar flechas de navegación",
+  "admin/editor.carousel.perPage.title": "Artículos por página",
   "admin/editor.carousel.height.title": "Altura máxima del banner (px)",
   "admin/editor.carousel.mobileHeight.title": "Altura máxima del banner en el móvil (px)",
   "admin/editor.carousel.autoplay.title": "Reproducción automática",

--- a/messages/es.json
+++ b/messages/es.json
@@ -19,6 +19,7 @@
   "admin/editor.carousel.banners.title": "Banners",
   "admin/editor.carousel.banner.title": "Banner",
   "admin/editor.carousel.banner.description.title": "Descripción del banner",
+  "admin/editor.carousel.banner.text.title": "Texto del banner",
   "admin/editor.carousel.banner.externalRoute.title": "Ruta externa",
   "admin/editor.carousel.banner.image.title": "Imagen del banner",
   "admin/editor.carousel.banner.mobileImage.title": "Imagen del banner en el móvil"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -19,6 +19,7 @@
   "admin/editor.carousel.banners.title": "Banners",
   "admin/editor.carousel.banner.title": "Banner",
   "admin/editor.carousel.banner.description.title": "Descrição do banner",
+  "admin/editor.carousel.banner.text.title": "Texto do banner",
   "admin/editor.carousel.banner.externalRoute.title": "Rota externa",
   "admin/editor.carousel.banner.image.title": "Imagem do banner",
   "admin/editor.carousel.banner.mobileImage.title": "Imagem do banner no mobile"

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,6 +3,7 @@
   "admin/editor.carousel.description": "Um componente básico de carrossel que exibe uma série de banners",
   "admin/editor.carousel.showDots.title": "Mostrar pontos",
   "admin/editor.carousel.showArrows.title": "Mostrar setas de navegação",
+  "admin/editor.carousel.perPage.title": "Items por página",
   "admin/editor.carousel.height.title": "Altura máxima do banner (px)",
   "admin/editor.carousel.mobileHeight.title": "Altura máxima do banner no mobile (px)",
   "admin/editor.carousel.autoplay.title": "Reprodução automática",

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -67,7 +67,7 @@ const Banner = (props: Props) => {
       <div
         className={classnames(
           handles.imgRegular,
-          'flex items-center justify-center flex-column'
+          'flex items-center justify-center'
         )}
         style={{ maxHeight: height }}
       >

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -5,7 +5,7 @@ import classnames from 'classnames'
 import { useCssHandles } from 'vtex.css-handles'
 import styles from './styles.css'
 
-const CSS_HANDLES = ['imgRegular', 'img', 'bannerLink'] as const
+const CSS_HANDLES = ['imgRegular', 'img', 'bannerLink', 'imgText'] as const
 
 export interface Props {
   /** The image of the banner */
@@ -14,6 +14,8 @@ export interface Props {
   mobileImage: string
   /** The description of the image */
   description: string
+  /** The text accompanying the image */
+  text: string
   /** Max height size of the banner */
   height: number
   /** The url where the image is pointing to, in case of external route */
@@ -53,6 +55,7 @@ const Banner = (props: Props) => {
     height = 420,
     externalRoute,
     description = '',
+    text = '',
     customInternalURL,
   } = props
 
@@ -64,7 +67,7 @@ const Banner = (props: Props) => {
       <div
         className={classnames(
           handles.imgRegular,
-          'flex items-center justify-center'
+          'flex items-center justify-center flex-column'
         )}
         style={{ maxHeight: height }}
       >
@@ -73,6 +76,9 @@ const Banner = (props: Props) => {
           src={isMobile && mobileImage ? mobileImage : image}
           alt={description}
         />
+        {text && (
+          <span className={classnames(handles.imgText)}>{text}</span>
+        )}
       </div>
     </div>
   )

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -26,6 +26,8 @@ interface Props {
   showArrows?: boolean
   /** Set visibility of dots */
   showDots?: boolean
+  /** Set per page items for carousel */
+  perPage?: number
 }
 
 interface ArrowProps {
@@ -37,7 +39,6 @@ interface ArrowContainerProps {
   children: React.ReactNode
 }
 
-const PER_PAGE = 1
 const CSS_HANDLES = [
   'arrow',
   'arrowLeft',
@@ -58,6 +59,7 @@ const Carousel = (props: Props) => {
     showDots = true,
     showArrows = true,
     autoplaySpeed = 5,
+    perPage = 1,
     banners: bannersProp
   } = props
   const [currentSlide, setCurrentSlide] = useState(0)
@@ -101,7 +103,7 @@ const Carousel = (props: Props) => {
   )
 
   const handleNextSlide = () => {
-    const nextSlide = ((currentSlide + 1 - PER_PAGE) % banners.length) + PER_PAGE
+    const nextSlide = ((currentSlide + 1 - perPage) % banners.length) + perPage
     setCurrentSlide(nextSlide)
   }
 
@@ -125,7 +127,7 @@ const Carousel = (props: Props) => {
           root: handles.sliderRoot,
           sliderFrame: handles.sliderFrame,
         }}
-        perPage={PER_PAGE}
+        perPage={perPage}
         arrowRender={showArrows && ArrowRender}
         currentSlide={currentSlide}
         onChangeSlide={setCurrentSlide}
@@ -146,7 +148,7 @@ const Carousel = (props: Props) => {
       {showDots && (
         <Dots
           loop
-          perPage={PER_PAGE}
+          perPage={perPage}
           currentSlide={currentSlide}
           totalSlides={banners.length}
           onChangeSlide={setCurrentSlide}
@@ -284,13 +286,16 @@ Carousel.getSchema = () => {
       },
       showArrows: {
         default: true,
-        isLayout: true,
         title: 'admin/editor.carousel.showArrows.title',
         type: 'boolean',
       },
+      perPage: {
+        default: 1,
+        title: 'admin/editor.carousel.perPage.title',
+        type: 'number'
+      },
       showDots: {
         default: true,
-        isLayout: true,
         title: 'admin/editor.carousel.showDots.title',
         type: 'boolean',
       },

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -241,6 +241,11 @@ Carousel.getSchema = () => {
               title: 'admin/editor.carousel.banner.description.title',
               type: 'string',
             },
+            text: {
+              default: '',
+              title: 'admin/editor.carousel.banner.text.title',
+              type: 'string',
+            },
             externalRoute: {
               default: false,
               isLayout: false,


### PR DESCRIPTION
#### What is the purpose of this pull request?
Give the ability to change items per page and put text  with image on carousel

#### What problem is this solving?
Allows you to show more than one item per page in the carousel and, if desired, show text

#### How should this be manually tested?
Change the per page number in carousel and add text property in your banner image

#### Screenshots or example usage


#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [X] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
