### PR TITLE
Feature: Custom mobile breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Use custom breakpoints values in `useDevice` hook
+
 ## [2.11.5] - 2019-12-18
 
 ### Added
+
 - Deprecation warning on the documentation
 
 ## [2.11.4] - 2019-10-25
@@ -22,11 +27,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [2.11.3] - 2019-10-25
 
 ### Chore
+
 - New release to trigger a rebuild enabling lazy evaluation of carousel entrypoints
 
 ## [2.11.2] - 2019-09-04
 
 ### Fixed
+
 - Fix autoplay speed warning and object keys order
 
 ## [2.11.1] - 2019-08-29

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,8 +2,6 @@
 
 :warning: This app is deprecated. Use the `slider-layout` app as this [recipe](https://vtex.io/docs/recipes/layout/building-a-carousel-through-lists-and-slider-layout) explains in order to replace it.
 
-
-
 ## Description
 
 The VTEX Carousel app is a store component that shows a collection of banners, and this app is used by store theme.
@@ -56,7 +54,11 @@ Now, you can change the behavior of the carousel block that is in the store head
       "banners": [],
       "height": 440,
       "showArrows": true,
-      "showDots": true
+      "showDots": true,
+      "breakpoints": {
+        "medium": "32rem",
+        "large": "60rem"
+      }
     }
   }
 ```
@@ -77,14 +79,15 @@ For now this block does not have any required or optional blocks.
 
 Through the Storefront, you can change the carousel's behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name       | Type            | Description                                        | Default value |
-| --------------- | --------------- | -------------------------------------------------- | ------------- |
-| `autoplay`      | `Boolean`       | Enable automatic banner transition                 | true          |
-| `autoplaySpeed` | `Number`        | Set the automatic banner transition interval       | 5             |
-| `showDots`      | `Boolean`       | Shows the carousel dots                            | true          |
-| `showArrows`    | `Boolean`       | Shows the carousel arrows                          | true          |
-| `height`        | `Number`        | Set banners height                                 | 420           |
-| `banners`       | `Array(Banner)` | Array of banners the will be shown in the carousel | []            |
+| Prop name       | Type            | Description                                              | Default value                 |
+| --------------- | --------------- | -------------------------------------------------------- | ----------------------------- |
+| `autoplay`      | `Boolean`       | Enable automatic banner transition                       | true                          |
+| `autoplaySpeed` | `Number`        | Set the automatic banner transition interval             | 5                             |
+| `showDots`      | `Boolean`       | Shows the carousel dots                                  | true                          |
+| `showArrows`    | `Boolean`       | Shows the carousel arrows                                | true                          |
+| `height`        | `Number`        | Set banners height                                       | 420                           |
+| `banners`       | `Array(Banner)` | Array of banners the will be shown in the carousel       | []                            |
+| `breakpoints`   | `Object`        | Object containing "medium" and "large" breakpoint values | { medium: null, large: null } |
 
 Banner:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Now, you can change the behavior of the carousel block that is in the store head
       "height": 440,
       "showArrows": true,
       "showDots": true,
-      "breakpoints": {
+      "experimentalBreakpoints": {
         "medium": "32rem",
         "large": "60rem"
       }
@@ -79,15 +79,15 @@ For now this block does not have any required or optional blocks.
 
 Through the Storefront, you can change the carousel's behavior and interface. However, you also can make in your theme app, as Store theme does.
 
-| Prop name       | Type            | Description                                              | Default value                 |
-| --------------- | --------------- | -------------------------------------------------------- | ----------------------------- |
-| `autoplay`      | `Boolean`       | Enable automatic banner transition                       | true                          |
-| `autoplaySpeed` | `Number`        | Set the automatic banner transition interval             | 5                             |
-| `showDots`      | `Boolean`       | Shows the carousel dots                                  | true                          |
-| `showArrows`    | `Boolean`       | Shows the carousel arrows                                | true                          |
-| `height`        | `Number`        | Set banners height                                       | 420                           |
-| `banners`       | `Array(Banner)` | Array of banners the will be shown in the carousel       | []                            |
-| `breakpoints`   | `Object`        | Object containing "medium" and "large" breakpoint values | { medium: null, large: null } |
+| Prop name                 | Type            | Description                                              | Default value                 |
+| ------------------------- | --------------- | -------------------------------------------------------- | ----------------------------- |
+| `autoplay`                | `Boolean`       | Enable automatic banner transition                       | true                          |
+| `autoplaySpeed`           | `Number`        | Set the automatic banner transition interval             | 5                             |
+| `showDots`                | `Boolean`       | Shows the carousel dots                                  | true                          |
+| `showArrows`              | `Boolean`       | Shows the carousel arrows                                | true                          |
+| `height`                  | `Number`        | Set banners height                                       | 420                           |
+| `banners`                 | `Array(Banner)` | Array of banners the will be shown in the carousel       | []                            |
+| `experimentalBreakpoints` | `Object`        | Object containing "medium" and "large" breakpoint values | { medium: null, large: null } |
 
 Banner:
 

--- a/messages/context.json
+++ b/messages/context.json
@@ -20,5 +20,8 @@
   "admin/editor.carousel.banner.description.title": "admin/editor.carousel.banner.description.title",
   "admin/editor.carousel.banner.externalRoute.title": "admin/editor.carousel.banner.externalRoute.title",
   "admin/editor.carousel.banner.image.title": "admin/editor.carousel.banner.image.title",
-  "admin/editor.carousel.banner.mobileImage.title": "admin/editor.carousel.banner.mobileImage.title"
+  "admin/editor.carousel.banner.mobileImage.title": "admin/editor.carousel.banner.mobileImage.title",
+  "admin/editor.carousel.breakpoints.title": "admin/editor.carousel.breakpoints.title",
+  "admin/editor.carousel.breakpoints.medium.title": "admin/editor.carousel.breakpoints.medium.title",
+  "admin/editor.carousel.breakpoints.large.title": "admin/editor.carousel.breakpoints.large.title"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -20,5 +20,8 @@
   "admin/editor.carousel.banner.description.title": "Banner description",
   "admin/editor.carousel.banner.externalRoute.title": "External route",
   "admin/editor.carousel.banner.image.title": "Banner image",
-  "admin/editor.carousel.banner.mobileImage.title": "Banner mobile image"
+  "admin/editor.carousel.banner.mobileImage.title": "Banner mobile image",
+  "admin/editor.carousel.breakpoints.title": "Breakpoints",
+  "admin/editor.carousel.breakpoints.medium.title": "Breakpoint Medium",
+  "admin/editor.carousel.breakpoints.large.title": "Breakpoint Large"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -20,5 +20,8 @@
   "admin/editor.carousel.banner.description.title": "Descripción del banner",
   "admin/editor.carousel.banner.externalRoute.title": "Ruta externa",
   "admin/editor.carousel.banner.image.title": "Imagen del banner",
-  "admin/editor.carousel.banner.mobileImage.title": "Imagen del banner en el móvil"
+  "admin/editor.carousel.banner.mobileImage.title": "Imagen del banner en el móvil",
+  "admin/editor.carousel.breakpoints.title": "Breakpoints",
+  "admin/editor.carousel.breakpoints.medium.title": "Breakpoint Medio",
+  "admin/editor.carousel.breakpoints.large.title": "Breakpoint Grande"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -20,5 +20,8 @@
   "admin/editor.carousel.banner.description.title": "Descrição do banner",
   "admin/editor.carousel.banner.externalRoute.title": "Rota externa",
   "admin/editor.carousel.banner.image.title": "Imagem do banner",
-  "admin/editor.carousel.banner.mobileImage.title": "Imagem do banner no mobile"
+  "admin/editor.carousel.banner.mobileImage.title": "Imagem do banner no mobile",
+  "admin/editor.carousel.breakpoints.title": "Breakpoints",
+  "admin/editor.carousel.breakpoints.medium.title": "Breakpoint Médio",
+  "admin/editor.carousel.breakpoints.large.title": "Breakpoint Grande"
 }

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -34,7 +34,7 @@ export interface Props {
   /** Runtime injected deps */
   runtime: any
   /** Device Detector custom breakpoints */
-  breakpoints?: Breakpoints
+  experimentalBreakpoints?: Breakpoints
 }
 
 function getParams(params: string) {
@@ -61,10 +61,10 @@ const Banner = (props: Props) => {
     externalRoute,
     description = '',
     customInternalURL,
-    breakpoints,
+    experimentalBreakpoints,
   } = props
 
-  const { isMobile } = useDevice(breakpoints)
+  const { isMobile } = useDevice({ experimentalBreakpoints })
   const handles = useCssHandles(CSS_HANDLES)
 
   const content = (

--- a/react/Banner.tsx
+++ b/react/Banner.tsx
@@ -7,6 +7,11 @@ import styles from './styles.css'
 
 const CSS_HANDLES = ['imgRegular', 'img', 'bannerLink'] as const
 
+export interface Breakpoints {
+  medium: string
+  large: string
+}
+
 export interface Props {
   /** The image of the banner */
   image: string
@@ -28,6 +33,8 @@ export interface Props {
   customInternalURL: string
   /** Runtime injected deps */
   runtime: any
+  /** Device Detector custom breakpoints */
+  breakpoints?: Breakpoints
 }
 
 function getParams(params: string) {
@@ -54,9 +61,10 @@ const Banner = (props: Props) => {
     externalRoute,
     description = '',
     customInternalURL,
+    breakpoints,
   } = props
 
-  const { isMobile } = useDevice()
+  const { isMobile } = useDevice(breakpoints)
   const handles = useCssHandles(CSS_HANDLES)
 
   const content = (

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -4,7 +4,7 @@ import { Dots, Slide, Slider, SliderContainer } from 'vtex.slider'
 import { Container } from 'vtex.store-components'
 import { IconCaret } from 'vtex.store-icons'
 
-import Banner, { Props as BannerProps } from './Banner'
+import Banner, { Props as BannerProps, Breakpoints } from './Banner'
 import { useCssHandles } from 'vtex.css-handles'
 import styles from './styles.css'
 
@@ -26,6 +26,8 @@ interface Props {
   showArrows?: boolean
   /** Set visibility of dots */
   showDots?: boolean
+  /** Device Detector breakpoints */
+  breakpoints?: Breakpoints
 }
 
 interface ArrowProps {
@@ -58,7 +60,8 @@ const Carousel = (props: Props) => {
     showDots = true,
     showArrows = true,
     autoplaySpeed = 5,
-    banners: bannersProp
+    banners: bannersProp,
+    breakpoints,
   } = props
   const [currentSlide, setCurrentSlide] = useState(0)
   const handles = useCssHandles(CSS_HANDLES)
@@ -101,7 +104,8 @@ const Carousel = (props: Props) => {
   )
 
   const handleNextSlide = () => {
-    const nextSlide = ((currentSlide + 1 - PER_PAGE) % banners.length) + PER_PAGE
+    const nextSlide =
+      ((currentSlide + 1 - PER_PAGE) % banners.length) + PER_PAGE
     setCurrentSlide(nextSlide)
   }
 
@@ -139,7 +143,7 @@ const Carousel = (props: Props) => {
             style={{ maxHeight: height }}
             sliderTransitionDuration={500}
           >
-            <Banner height={height} {...banner} />
+            <Banner height={height} breakpoints={breakpoints} {...banner} />
           </Slide>
         ))}
       </Slider>
@@ -299,6 +303,23 @@ Carousel.getSchema = () => {
         isLayout: false,
         title: 'admin/editor.carousel.autoplay.title',
         type: 'boolean',
+      },
+      breakpoints: {
+        isLayout: false,
+        title: 'admin/editor.carousel.breakpoints.title',
+        type: 'object',
+        properties: {
+          medium: {
+            isLayout: false,
+            title: 'admin/editor.carousel.breakpoints.medium.title',
+            type: 'string',
+          },
+          large: {
+            isLayout: false,
+            title: 'admin/editor.carousel.breakpoints.large.title',
+            type: 'string',
+          },
+        },
       },
     },
     title: 'admin/editor.carousel.title',

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -27,7 +27,7 @@ interface Props {
   /** Set visibility of dots */
   showDots?: boolean
   /** Device Detector breakpoints */
-  breakpoints?: Breakpoints
+  experimentalBreakpoints?: Breakpoints
 }
 
 interface ArrowProps {
@@ -61,7 +61,7 @@ const Carousel = (props: Props) => {
     showArrows = true,
     autoplaySpeed = 5,
     banners: bannersProp,
-    breakpoints,
+    experimentalBreakpoints,
   } = props
   const [currentSlide, setCurrentSlide] = useState(0)
   const handles = useCssHandles(CSS_HANDLES)
@@ -143,7 +143,11 @@ const Carousel = (props: Props) => {
             style={{ maxHeight: height }}
             sliderTransitionDuration={500}
           >
-            <Banner height={height} breakpoints={breakpoints} {...banner} />
+            <Banner
+              height={height}
+              experimentalBreakpoints={experimentalBreakpoints}
+              {...banner}
+            />
           </Slide>
         ))}
       </Slider>
@@ -304,7 +308,7 @@ Carousel.getSchema = () => {
         title: 'admin/editor.carousel.autoplay.title',
         type: 'boolean',
       },
-      breakpoints: {
+      experimentalBreakpoints: {
         isLayout: false,
         title: 'admin/editor.carousel.breakpoints.title',
         type: 'object',


### PR DESCRIPTION
#### What is the purpose of this pull request?
Exposes via props an API that enables custom breakpoints to be specified.

#### What problem is this solving?
[Refer to](https://github.com/vtex-apps/device-detector/pull/10)

#### How should this be manually tested?

- Go to [Workspace](https://fixsliderbreakpoint--unimarcdev.myvtex.com);
- Observe that the main carousel now breaks at `60rem` (custom breakpoint);

#### Screenshots or example usage

```json
{
"carousel#home": {
    "props": {
      "autoplay": true,
      "autoplaySpeed": 4,
      "banners": [...],
      "height": 400,
      "showArrows": true,
      "showDots": true,
      "breakpoints": {
        "large": "60rem"
      }
    }
  }
}
```

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Requires change to documentation, which has been updated accordingly.
