### PR TITLE
Update README.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
++ Issue with _Building a Carousel using Slider Layout_ documentation link.
 
 ## [2.12.2] - 2020-08-05
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # VTEX Carousel ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red)
 
-:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) to keep up with the component's evolution.
+:warning:**The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) to keep up with the component's evolution.
 
 :loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,9 +2,10 @@
 
 :warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) to keep up with the component's evolution.
 
+:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
+
 The VTEX Carousel app is a store component that shows a collection of banners, and this app is used by store theme.
 
-:loudspeaker: **Disclaimer:** Don't fork this project; use, contribute, or open issue with your feature request.
 
 ## Release schedule
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # VTEX Carousel ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red)
 
-:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you to [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) in order to keep up with the component's evolution.
+:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) to keep up with the component's evolution.
 
 The VTEX Carousel app is a store component that shows a collection of banners, and this app is used by store theme.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # VTEX Carousel ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red)
 
-:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you to [update your store theme's carousel using the Slider Layout](https://vtex.io/docs/recipes/layout/building-a-carousel-through-lists-and-slider-layout) in order to keep up with the component's evolution.
+:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you to [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) in order to keep up with the component's evolution.
 
 The VTEX Carousel app is a store component that shows a collection of banners, and this app is used by store theme.
 

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -146,7 +146,7 @@ const Carousel = (props: Props) => {
             style={{ maxHeight: height }}
             sliderTransitionDuration={500}
           >
-            <Banner {...banner} />
+             <Banner height={height} {...banner} />
           </Slide>
         ))}
       </Slider>

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -146,7 +146,7 @@ const Carousel = (props: Props) => {
             style={{ maxHeight: height }}
             sliderTransitionDuration={500}
           >
-            <Banner height={height} {...banner} />
+            <Banner {...banner} />
           </Slide>
         ))}
       </Slider>

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -146,7 +146,7 @@ const Carousel = (props: Props) => {
             style={{ maxHeight: height }}
             sliderTransitionDuration={500}
           >
-            <Banner {...banner} />
+            <Banner {...banner} height={banner.height ?? height} />
           </Slide>
         ))}
       </Slider>

--- a/react/Carousel.tsx
+++ b/react/Carousel.tsx
@@ -146,7 +146,7 @@ const Carousel = (props: Props) => {
             style={{ maxHeight: height }}
             sliderTransitionDuration={500}
           >
-             <Banner height={height} {...banner} />
+            <Banner {...banner} />
           </Slide>
         ))}
       </Slider>


### PR DESCRIPTION
#### What problem is this solving?

Fix the "Building a Carousel using Slider Layout" link.
#### How to test it?

1. Go to the 1st paragraph

> :warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you to [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) in order to keep up with the component's evolution.

2. Click on the link that redirects you to the documentation for _Building a Carousel using Slider layout_ and see if the link is the following (and it's not broken): https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![relieved](https://media.giphy.com/media/cgW5iwX0e37qg/giphy.gif)
