### PR TITLE
Update README.md

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # VTEX Carousel ![https://img.shields.io/badge/-Deprecated-red](https://img.shields.io/badge/-Deprecated-red)
 
-:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you to [update your store theme's carousel using the Slider Layout](https://vtex.io/docs/recipes/layout/building-a-carousel-through-lists-and-slider-layout) in order to keep up with the component's evolution.
+:warning: **The Carousel app has been deprecated**. Although support for this block is still granted, we strongly recommend you to [update your store theme's carousel using the Slider Layout](https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout) in order to keep up with the component's evolution.
 
 The VTEX Carousel app is a store component that shows a collection of banners, and this app is used by store theme.
 


### PR DESCRIPTION
#### What problem is this solving?

Fix the "Building a Carousel using Slider Layout" link.

How to test it?
Go to the 1st paragraph
⚠️ The Carousel app has been deprecated. Although support for this block is still granted, we strongly recommend you to update your store theme's carousel using the Slider Layout in order to keep up with the component's evolution.

Click on the link that redirects you to the documentation for Building a Carousel using Slider layout and see if the link is the following (and it's not broken): https://developers.vtex.com/vtex-developer-docs/docs/vtex-io-documentation-building-a-carousel-using-slider-layout